### PR TITLE
Fix two reported sampling issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 restore:
 	git restore man/figures/logo.png docs/reference/figures/logo.png docs/logo.png
+	git restore docs/CNAME
 
 website:
 	rm -rf docs/ man/; mkdir -p man/figures

--- a/R/interface.R
+++ b/R/interface.R
@@ -933,6 +933,8 @@ sampling <- function(model, times, ..., strict = FALSE) {
   if (!inherits(model, "slendr_model"))
     stop("A slendr_model object must be specified", call. = FALSE)
 
+  times <- unique(as.integer(sort(times)))
+
   samples <- list(...)
   sample_pops <- purrr::map(samples, 1)
   sample_counts <- purrr::map(samples, 2)
@@ -965,9 +967,8 @@ sampling <- function(model, times, ..., strict = FALSE) {
       n <- s[[2]]
       tryCatch(
         {
-          t <- as.integer(t)
           check_removal_time(t, pop, direction = model$direction)
-          check_present_time(t, pop, direction = model$direction)
+          check_present_time(t, pop, direction = model$direction, offset = model$generation_time)
           if (!is.infinite(n)) n <- as.integer(n)
           dplyr::tibble(time = t, pop = pop$pop[1], n = n)
         },

--- a/R/utils.R
+++ b/R/utils.R
@@ -229,14 +229,18 @@ check_event_time <- function(time, pop) {
     stop(sprintf("Unknown time direction %s", direction), call. = FALSE)
 }
 
-check_present_time <- function(time, pop, direction = NULL, offset = 0) {
+# Check whether a given population will be present for sampling
+# (used exclusively in the sampling() function to avoid situations when
+# a user would sample from a population in the same generation that it
+# would be created)
+check_present_time <- function(time, pop, offset, direction = NULL) {
   if (is.null(direction))
     direction <- get_time_direction(pop)
   split_time <- get_lineage_splits(pop)[1]
 
-  if (direction == "backward" & time >= split_time - offset)
-    stop("Population ", pop$pop[1], " is not present at a time ", time, call. = FALSE)
-  else if (direction == "forward" & time <= split_time + offset)
+  if (time == split_time |
+      (direction == "backward" & time > split_time - offset) |
+      (direction == "forward" & time < split_time + offset))
     stop("Population ", pop$pop[1], " is not present at a time ", time, call. = FALSE)
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -229,14 +229,14 @@ check_event_time <- function(time, pop) {
     stop(sprintf("Unknown time direction %s", direction), call. = FALSE)
 }
 
-check_present_time <- function(time, pop, direction = NULL) {
+check_present_time <- function(time, pop, direction = NULL, offset = 0) {
   if (is.null(direction))
     direction <- get_time_direction(pop)
   split_time <- get_lineage_splits(pop)[1]
 
-  if (direction == "backward" & time >= split_time)
+  if (direction == "backward" & time >= split_time - offset)
     stop("Population ", pop$pop[1], " is not present at a time ", time, call. = FALSE)
-  else if (direction == "forward" & time <= split_time)
+  else if (direction == "forward" & time <= split_time + offset)
     stop("Population ", pop$pop[1], " is not present at a time ", time, call. = FALSE)
 }
 

--- a/README.md
+++ b/README.md
@@ -236,9 +236,9 @@ slim(
 #> 
 #> /usr/local/bin/slim  \
 #>     -d SEED=314159  \
-#>     -d 'SAMPLES="/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//RtmpBVZCpY/file7fbd53fb84b3"' \
-#>     -d 'MODEL="/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//RtmpBVZCpY/readme-model"' \
-#>     -d 'OUTPUT="/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//RtmpBVZCpY/readme-model/output"' \
+#>     -d 'SAMPLES="/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//Rtmp85i4q9/file168538bc8ff7"' \
+#>     -d 'MODEL="/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//Rtmp85i4q9/readme-model"' \
+#>     -d 'OUTPUT="/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//Rtmp85i4q9/readme-model/output"' \
 #>     -d SPATIAL=T \
 #>     -d SEQUENCE_LENGTH=1 \
 #>     -d RECOMB_RATE=0 \
@@ -246,7 +246,7 @@ slim(
 #>     -d SIMULATION_LENGTH=1733 \
 #>     -d SAVE_LOCATIONS=T \
 #>     -d MAX_ATTEMPTS=10 \
-#>     /var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//RtmpBVZCpY/readme-model/script.slim 
+#>     /var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//Rtmp85i4q9/readme-model/script.slim 
 #> --------------------------------------------------
 ```
 

--- a/docs/articles/index.html
+++ b/docs/articles/index.html
@@ -191,6 +191,8 @@
         <dd></dt>
         <dt><a href="vignette-07-msprime.html">Simulating slendr models with msprime</a></dt>
         <dd></dt>
+        <dt><a href="vignette-08-paper.html">Examples from the slendr paper</a></dt>
+        <dd></dt>
       </dl>
     </div>
   </div>

--- a/docs/articles/vignette-01-tutorial.html
+++ b/docs/articles/vignette-01-tutorial.html
@@ -176,7 +176,7 @@
 <li>Install <em>slendr</em>:</li>
 </ol>
 <div class="sourceCode" id="cb2"><pre class="downlit sourceCode r">
-<code class="sourceCode R"><span class="fu">devtools</span><span class="fu">::</span><span class="fu"><a href="https://devtools.r-lib.org//reference/remote-reexports.html">install_github</a></span><span class="op">(</span><span class="st">"bodkan/slendr"</span><span class="op">)</span></code></pre></div>
+<code class="sourceCode R"><span class="fu">devtools</span><span class="fu">::</span><span class="fu"><a href="https://devtools.r-lib.org/reference/remote-reexports.html">install_github</a></span><span class="op">(</span><span class="st">"bodkan/slendr"</span><span class="op">)</span></code></pre></div>
 <p>This is necessary because <em>slendr</em> is not on <a href="http://cran.r-project.org">CRAN</a> yet. Once it is there, it will be possible to install it by simply running <code><a href="https://rdrr.io/r/utils/install.packages.html">install.packages("slendr")</a></code> in your R console.</p>
 <ol start="4" style="list-style-type: decimal">
 <li>That’s it! You can now load the package with the usual:</li>
@@ -200,7 +200,7 @@
   crs <span class="op">=</span> <span class="st">"EPSG:3035"</span>    <span class="co"># projected CRS used internally</span>
 <span class="op">)</span></code></pre></div>
 <pre><code>#&gt; OGR data source with driver: ESRI Shapefile 
-#&gt; Source: "/private/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T/Rtmp8iKMAr", layer: "ne_110m_land"
+#&gt; Source: "/private/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T/RtmpCkOEZt", layer: "ne_110m_land"
 #&gt; with 127 features
 #&gt; It has 3 fields</code></pre>
 <p>Internally, the <code>map</code> object is currently a normal <code>sf</code> class object without additional components. This is unlike other <code>slendr</code> objects described below, which are also <code>sf</code> objects but which carry additional internal components.</p>
@@ -598,9 +598,9 @@ between populations.</code></pre>
 #&gt; 
 #&gt; /usr/local/bin/slim  \
 #&gt;     -d SEED=314159  \
-#&gt;     -d 'SAMPLES="/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//Rtmp8iKMAr/file806d146b1545"' \
-#&gt;     -d 'MODEL="/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//Rtmp8iKMAr/tutorial-model"' \
-#&gt;     -d 'OUTPUT="/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//Rtmp8iKMAr/tutorial-model/output"' \
+#&gt;     -d 'SAMPLES="/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//RtmpCkOEZt/file175f178a53fd"' \
+#&gt;     -d 'MODEL="/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//RtmpCkOEZt/tutorial-model"' \
+#&gt;     -d 'OUTPUT="/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//RtmpCkOEZt/tutorial-model/output"' \
 #&gt;     -d SPATIAL=T \
 #&gt;     -d SEQUENCE_LENGTH=1 \
 #&gt;     -d RECOMB_RATE=0 \
@@ -608,7 +608,7 @@ between populations.</code></pre>
 #&gt;     -d SIMULATION_LENGTH=1733 \
 #&gt;     -d SAVE_LOCATIONS=T \
 #&gt;     -d MAX_ATTEMPTS=10 \
-#&gt;     /var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//Rtmp8iKMAr/tutorial-model/script.slim 
+#&gt;     /var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//RtmpCkOEZt/tutorial-model/script.slim 
 #&gt; --------------------------------------------------</code></pre>
 <p>By default, simulation output files are put in the same directory where the model configuration data is stored, and are given a common prefix <code>output_</code>. Both the directory and the output file prefix can be specified by setting the <code>output_dir</code> and <code>output_prefix</code> arguments of the function <code><a href="../reference/slim.html">slim()</a></code>.</p>
 </div>

--- a/docs/articles/vignette-02-grid-model.html
+++ b/docs/articles/vignette-02-grid-model.html
@@ -257,7 +257,7 @@
   crs <span class="op">=</span> <span class="fl">4326</span>
 <span class="op">)</span></code></pre></div>
 <pre><code>#&gt; OGR data source with driver: ESRI Shapefile 
-#&gt; Source: "/private/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T/RtmpwfcT0C", layer: "ne_110m_land"
+#&gt; Source: "/private/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T/RtmpJ7UF1d", layer: "ne_110m_land"
 #&gt; with 127 features
 #&gt; It has 3 fields</code></pre>
 <div class="sourceCode" id="cb17"><pre class="downlit sourceCode r">

--- a/docs/articles/vignette-03-interactions.html
+++ b/docs/articles/vignette-03-interactions.html
@@ -191,9 +191,9 @@
 #&gt; 
 #&gt; /usr/local/bin/slim  \
 #&gt;     -d SEED=314159  \
-#&gt;     -d 'SAMPLES="/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//Rtmp240aCQ/file84cb6bbbd5db"' \
-#&gt;     -d 'MODEL="/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//Rtmp240aCQ/spatial-interactions"' \
-#&gt;     -d 'OUTPUT="/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//Rtmp240aCQ/spatial-interactions/output"' \
+#&gt;     -d 'SAMPLES="/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//RtmpJQ8FqZ/file182a237acea9"' \
+#&gt;     -d 'MODEL="/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//RtmpJQ8FqZ/spatial-interactions"' \
+#&gt;     -d 'OUTPUT="/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//RtmpJQ8FqZ/spatial-interactions/output"' \
 #&gt;     -d SPATIAL=T \
 #&gt;     -d SEQUENCE_LENGTH=1 \
 #&gt;     -d RECOMB_RATE=0 \
@@ -201,7 +201,7 @@
 #&gt;     -d SIMULATION_LENGTH=1000 \
 #&gt;     -d SAVE_LOCATIONS=T \
 #&gt;     -d MAX_ATTEMPTS=10 \
-#&gt;     /var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//Rtmp240aCQ/spatial-interactions/script.slim 
+#&gt;     /var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//RtmpJQ8FqZ/spatial-interactions/script.slim 
 #&gt; --------------------------------------------------</code></pre>
 <p>Once the simulation has finished running, we can recapitulate the spatial population dynamics simulated by the SLiM back end script as an animated GIF:</p>
 <div class="sourceCode" id="cb9"><pre class="downlit sourceCode r">

--- a/docs/articles/vignette-05-tree-sequences.html
+++ b/docs/articles/vignette-05-tree-sequences.html
@@ -179,8 +179,8 @@
 <pre><code>#&gt; # A tibble: 2 × 3
 #&gt;    time pop       n
 #&gt;   &lt;int&gt; &lt;chr&gt; &lt;int&gt;
-#&gt; 1 70000 NEA       1
-#&gt; 2 40000 NEA       1</code></pre>
+#&gt; 1 40000 NEA       1
+#&gt; 2 70000 NEA       1</code></pre>
 <p>As you can see, the <code><a href="../reference/sampling.html">sampling()</a></code> function simply accepts the vector of times at which remembering should be schedule, and then a list of pairs <code>(&lt;slendr population&gt;, &lt;number of individuals&gt;)</code> encoding from which populations should how many individuals be remembered at time points given in the <code>times</code> vector.</p>
 <p>Next, we want to sample some present-day individuals: an outgroup representing a chimpanzee, and a couple of Africans and Europeans:</p>
 <div class="sourceCode" id="cb5"><pre class="downlit sourceCode r">
@@ -199,16 +199,16 @@
 <pre><code>#&gt; # A tibble: 40 × 3
 #&gt;     time pop       n
 #&gt;    &lt;int&gt; &lt;chr&gt; &lt;int&gt;
-#&gt;  1 16361 EUR       1
-#&gt;  2 29322 EUR       1
-#&gt;  3 16979 EUR       1
-#&gt;  4 22342 EUR       1
-#&gt;  5 37738 EUR       1
-#&gt;  6 25728 EUR       1
-#&gt;  7 28594 EUR       1
-#&gt;  8 18357 EUR       1
-#&gt;  9 20367 EUR       1
-#&gt; 10 24655 EUR       1
+#&gt;  1 10319 EUR       1
+#&gt;  2 11187 EUR       1
+#&gt;  3 11395 EUR       1
+#&gt;  4 11529 EUR       1
+#&gt;  5 11927 EUR       1
+#&gt;  6 12675 EUR       1
+#&gt;  7 13689 EUR       1
+#&gt;  8 13744 EUR       1
+#&gt;  9 14774 EUR       1
+#&gt; 10 16361 EUR       1
 #&gt; # … with 30 more rows</code></pre>
 <p>This samples a single ancient European individuals at randomly chosen times between 40 and 10 ky ago.</p>
 <p>One nice feature of the <code><a href="../reference/sampling.html">sampling()</a></code> function is that it only schedules sampling events for a population, if that population is present in the simulation at a given time. This makes it possible to simply take a wide time range for sampling, specify all populations and sizes of the samples, and let the function generate sampling events only for populations present at each time. If for some reason a stricter control over sampling is required, this behavior can be switched off by setting <code>strict = TRUE</code> like this:</p>
@@ -229,9 +229,9 @@
 #&gt; 
 #&gt; /usr/local/bin/slim  \
 #&gt;     -d SEED=314159  \
-#&gt;     -d 'SAMPLES="/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//RtmpAONOpJ/file853021830dde"' \
-#&gt;     -d 'MODEL="/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//RtmpAONOpJ/introgression"' \
-#&gt;     -d 'OUTPUT="/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//RtmpAONOpJ/introgression/output"' \
+#&gt;     -d 'SAMPLES="/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//RtmpgXWavv/file18f229f8466"' \
+#&gt;     -d 'MODEL="/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//RtmpgXWavv/introgression"' \
+#&gt;     -d 'OUTPUT="/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//RtmpgXWavv/introgression/output"' \
 #&gt;     -d SPATIAL=F \
 #&gt;     -d SEQUENCE_LENGTH=10000000 \
 #&gt;     -d RECOMB_RATE=1e-08 \
@@ -239,7 +239,7 @@
 #&gt;     -d SIMULATION_LENGTH=216667 \
 #&gt;     -d SAVE_LOCATIONS=F \
 #&gt;     -d MAX_ATTEMPTS=10 \
-#&gt;     /var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//RtmpAONOpJ/introgression/script.slim 
+#&gt;     /var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//RtmpgXWavv/introgression/script.slim 
 #&gt; --------------------------------------------------</code></pre>
 </div>
 <div id="r-interface-for-tskit-and-pyslim" class="section level2">
@@ -315,7 +315,7 @@
 #&gt; ╟───────────┼──────┼────────┼────────────╢
 #&gt; ║Populations│     5│ 3.1 KiB│         Yes║
 #&gt; ╟───────────┼──────┼────────┼────────────╢
-#&gt; ║Provenances│     1│29.8 KiB│          No║
+#&gt; ║Provenances│     1│30.0 KiB│          No║
 #&gt; ╟───────────┼──────┼────────┼────────────╢
 #&gt; ║Sites      │     0│ 8 Bytes│          No║
 #&gt; ╚═══════════╧══════╧════════╧════════════╝</code></pre>
@@ -352,7 +352,7 @@
 #&gt; ╟───────────┼─────┼─────────┼────────────╢
 #&gt; ║Populations│    5│  3.1 KiB│         Yes║
 #&gt; ╟───────────┼─────┼─────────┼────────────╢
-#&gt; ║Provenances│    2│ 30.3 KiB│          No║
+#&gt; ║Provenances│    2│ 30.5 KiB│          No║
 #&gt; ╟───────────┼─────┼─────────┼────────────╢
 #&gt; ║Sites      │    0│  8 Bytes│          No║
 #&gt; ╚═══════════╧═════╧═════════╧════════════╝</code></pre>
@@ -389,7 +389,7 @@
 #&gt; ╟───────────┼─────┼─────────┼────────────╢
 #&gt; ║Populations│    5│  3.1 KiB│         Yes║
 #&gt; ╟───────────┼─────┼─────────┼────────────╢
-#&gt; ║Provenances│    3│ 30.8 KiB│          No║
+#&gt; ║Provenances│    3│ 31.0 KiB│          No║
 #&gt; ╟───────────┼─────┼─────────┼────────────╢
 #&gt; ║Sites      │    0│  8 Bytes│          No║
 #&gt; ╚═══════════╧═════╧═════════╧════════════╝</code></pre>
@@ -431,7 +431,7 @@
 #&gt; ╟───────────┼─────┼─────────┼────────────╢
 #&gt; ║Populations│    5│  3.1 KiB│         Yes║
 #&gt; ╟───────────┼─────┼─────────┼────────────╢
-#&gt; ║Provenances│    3│ 31.0 KiB│          No║
+#&gt; ║Provenances│    3│ 31.3 KiB│          No║
 #&gt; ╟───────────┼─────┼─────────┼────────────╢
 #&gt; ║Sites      │58089│964.4 KiB│          No║
 #&gt; ╚═══════════╧═════╧═════════╧════════════╝</code></pre>

--- a/docs/articles/vignette-06-locations.html
+++ b/docs/articles/vignette-06-locations.html
@@ -161,7 +161,7 @@
   crs <span class="op">=</span> <span class="st">"EPSG:3035"</span>
 <span class="op">)</span></code></pre></div>
 <pre><code>#&gt; OGR data source with driver: ESRI Shapefile 
-#&gt; Source: "/private/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T/Rtmp5IMvr4", layer: "ne_110m_land"
+#&gt; Source: "/private/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T/RtmpXIfmrf", layer: "ne_110m_land"
 #&gt; with 127 features
 #&gt; It has 3 fields</code></pre>
 <div class="sourceCode" id="cb4"><pre class="downlit sourceCode r">
@@ -274,9 +274,9 @@
 #&gt; 
 #&gt; /usr/local/bin/slim  \
 #&gt;     -d SEED=314159  \
-#&gt;     -d 'SAMPLES="/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//Rtmp5IMvr4/file85ce77c4fc79"' \
-#&gt;     -d 'MODEL="/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//Rtmp5IMvr4/spatial-ts"' \
-#&gt;     -d 'OUTPUT="/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//Rtmp5IMvr4/spatial-ts/output"' \
+#&gt;     -d 'SAMPLES="/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//RtmpXIfmrf/file1eb3527a74ae"' \
+#&gt;     -d 'MODEL="/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//RtmpXIfmrf/spatial-ts"' \
+#&gt;     -d 'OUTPUT="/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//RtmpXIfmrf/spatial-ts/output"' \
 #&gt;     -d SPATIAL=T \
 #&gt;     -d SEQUENCE_LENGTH=100000 \
 #&gt;     -d RECOMB_RATE=1e-08 \
@@ -284,7 +284,7 @@
 #&gt;     -d SIMULATION_LENGTH=1733 \
 #&gt;     -d SAVE_LOCATIONS=F \
 #&gt;     -d MAX_ATTEMPTS=1 \
-#&gt;     /var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//Rtmp5IMvr4/spatial-ts/script.slim 
+#&gt;     /var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//RtmpXIfmrf/spatial-ts/script.slim 
 #&gt; --------------------------------------------------</code></pre>
 <p>After the simulation is done, we can load the data in the same way we did in our <a href="vignette-05-tree%20sequences.html#loading-and-processing-tree%20sequence-output-files-1">first exploration</a> of tree sequence features in <em>slendr</em>. We will also immediately simplify the tree sequence data structure to only those genealogies which involve individuals that we explicitly scheduled for sampling, and perform recapitation to ensure the coalescence of all genealogies along the genome:</p>
 <div class="sourceCode" id="cb11"><pre class="downlit sourceCode r">
@@ -321,7 +321,7 @@
 #&gt; oldest sampled individual: 40000 backward time units
 #&gt; youngest sampled individual: 0 backward time units
 #&gt; 
-#&gt; oldest node: 1757270 backward time units
+#&gt; oldest node: 2192941 backward time units
 #&gt; youngest node: 0 backward time units
 #&gt; ---------------------- 
 #&gt; contents of the underlying sf object:
@@ -371,7 +371,7 @@
 #&gt; oldest sampled individual: 40000 backward time units
 #&gt; youngest sampled individual: 0 backward time units
 #&gt; 
-#&gt; oldest node: 1757270 backward time units
+#&gt; oldest node: 2192941 backward time units
 #&gt; youngest node: 0 backward time units
 #&gt; ---------------------- 
 #&gt; contents of the underlying sf object:
@@ -474,18 +474,18 @@
 #&gt; Bounding box:  xmin: 2364888 ymin: 435446 xmax: 8488953 ymax: 4763638
 #&gt; Projected CRS: ETRS89-extended / LAEA Europe
 #&gt; # A tibble: 95 × 15
-#&gt;    name   pop   node_id level child_id child_time parent_id parent_time child_pop
-#&gt;  * &lt;chr&gt;  &lt;fct&gt;   &lt;int&gt; &lt;fct&gt;    &lt;int&gt;      &lt;int&gt;     &lt;int&gt;       &lt;int&gt; &lt;fct&gt;    
-#&gt;  1 EUR_25 EUR       190 1          190          0       260         450 EUR      
-#&gt;  2 EUR_25 EUR       190 2          260        450       262         510 EUR      
-#&gt;  3 EUR_25 EUR       190 3          262        510       263         570 EUR      
-#&gt;  4 EUR_25 EUR       190 4          263        570       282        3090 EUR      
-#&gt;  5 EUR_25 EUR       190 5          282       3090       292        4290 EUR      
-#&gt;  6 EUR_25 EUR       190 6          292       4290       300        6000 YAM      
-#&gt;  7 EUR_25 EUR       190 7          300       6000       307        6840 YAM      
-#&gt;  8 EUR_25 EUR       190 8          307       6840       332       10830 YAM      
-#&gt;  9 EUR_25 EUR       190 8          307       6840       347       13800 YAM      
-#&gt; 10 EUR_25 EUR       190 9          332      10830       390       19860 EHG      
+#&gt;    name  pop   node_id level child_id child_time parent_id parent_time child_pop
+#&gt;  * &lt;chr&gt; &lt;fct&gt;   &lt;int&gt; &lt;fct&gt;    &lt;int&gt;      &lt;int&gt;     &lt;int&gt;       &lt;int&gt; &lt;fct&gt;    
+#&gt;  1 EUR_… EUR       190 1          190          0       260         450 EUR      
+#&gt;  2 EUR_… EUR       190 2          260        450       262         510 EUR      
+#&gt;  3 EUR_… EUR       190 3          262        510       263         570 EUR      
+#&gt;  4 EUR_… EUR       190 4          263        570       282        3090 EUR      
+#&gt;  5 EUR_… EUR       190 5          282       3090       292        4290 EUR      
+#&gt;  6 EUR_… EUR       190 6          292       4290       300        6000 YAM      
+#&gt;  7 EUR_… EUR       190 7          300       6000       307        6840 YAM      
+#&gt;  8 EUR_… EUR       190 8          307       6840       332       10830 YAM      
+#&gt;  9 EUR_… EUR       190 8          307       6840       347       13800 YAM      
+#&gt; 10 EUR_… EUR       190 9          332      10830       390       19860 EHG      
 #&gt; # … with 85 more rows, and 6 more variables: parent_pop &lt;fct&gt;,
 #&gt; #   child_location &lt;POINT [m]&gt;, parent_location &lt;POINT [m]&gt;,
 #&gt; #   connection &lt;LINESTRING [m]&gt;, left_pos &lt;dbl&gt;, right_pos &lt;dbl&gt;</code></pre>

--- a/docs/index.html
+++ b/docs/index.html
@@ -326,9 +326,9 @@
 <span class="co">#&gt; </span>
 <span class="co">#&gt; /usr/local/bin/slim  \</span>
 <span class="co">#&gt;     -d SEED=314159  \</span>
-<span class="co">#&gt;     -d 'SAMPLES="/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//RtmpBVZCpY/file7fbd53fb84b3"' \</span>
-<span class="co">#&gt;     -d 'MODEL="/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//RtmpBVZCpY/readme-model"' \</span>
-<span class="co">#&gt;     -d 'OUTPUT="/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//RtmpBVZCpY/readme-model/output"' \</span>
+<span class="co">#&gt;     -d 'SAMPLES="/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//Rtmp85i4q9/file168538bc8ff7"' \</span>
+<span class="co">#&gt;     -d 'MODEL="/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//Rtmp85i4q9/readme-model"' \</span>
+<span class="co">#&gt;     -d 'OUTPUT="/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//Rtmp85i4q9/readme-model/output"' \</span>
 <span class="co">#&gt;     -d SPATIAL=T \</span>
 <span class="co">#&gt;     -d SEQUENCE_LENGTH=1 \</span>
 <span class="co">#&gt;     -d RECOMB_RATE=0 \</span>
@@ -336,7 +336,7 @@
 <span class="co">#&gt;     -d SIMULATION_LENGTH=1733 \</span>
 <span class="co">#&gt;     -d SAVE_LOCATIONS=T \</span>
 <span class="co">#&gt;     -d MAX_ATTEMPTS=10 \</span>
-<span class="co">#&gt;     /var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//RtmpBVZCpY/readme-model/script.slim </span>
+<span class="co">#&gt;     /var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//Rtmp85i4q9/readme-model/script.slim </span>
 <span class="co">#&gt; --------------------------------------------------</span></code></pre></div>
 <p>As specified, the SLiM run will save ancestry proportions in each population over time as well as the location of every individual who ever lived.</p>
 </div>

--- a/docs/pkgdown.yml
+++ b/docs/pkgdown.yml
@@ -1,4 +1,4 @@
-pandoc: 2.14.0.3
+pandoc: '2.13'
 pkgdown: 1.6.1
 pkgdown_sha: ~
 articles:
@@ -9,7 +9,8 @@ articles:
   vignette-05-tree-sequences: vignette-05-tree-sequences.html
   vignette-06-locations: vignette-06-locations.html
   vignette-07-msprime: vignette-07-msprime.html
-last_built: 2021-11-25T00:10Z
+  vignette-08-paper: vignette-08-paper.html
+last_built: 2021-12-06T10:18Z
 urls:
   reference: https://www.slendr.net/reference
   article: https://www.slendr.net/articles

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -180,4 +180,7 @@
   <url>
     <loc>https://www.slendr.net/articles/vignette-07-msprime.html</loc>
   </url>
+  <url>
+    <loc>https://www.slendr.net/articles/vignette-08-paper.html</loc>
+  </url>
 </urlset>

--- a/inst/extdata/script.slim
+++ b/inst/extdata/script.slim
@@ -342,6 +342,9 @@ s10 late() /* Remember individuals for tree sequence recording */ {
         pop = event.getValue("pop"); n = event.getValue("n");
         all_inds = get_pop(pop).individuals;
 
+        // only individuals not yet sampled are eligible for remembering
+        all_inds = all_inds[all_inds.tag != 1];
+
         if (isInfinite(n)) {
             n = length(all_inds);
             n_str = "all (" + n + ")";
@@ -364,6 +367,7 @@ s10 late() /* Remember individuals for tree sequence recording */ {
         }
 
         inds = sample(all_inds, asInteger(n));
+        inds.tag = 1; // tag sampled individuals as remembered
         sim.treeSeqRememberIndividuals(inds, permanent = T);
     }
 }
@@ -418,6 +422,9 @@ s12 late() /* End of simulation */ {
 }
 
 modifyChild() /* Place offspring within its population's boundary */ {
+    // set flag marking availability for sampling
+    child.tag = 0;
+
     if (!SPATIAL) return T;
 
     // in case of spatially non-overlapping geneflow, assign locations uniformly

--- a/tests/testthat/test-sampling.R
+++ b/tests/testthat/test-sampling.R
@@ -43,3 +43,15 @@ test_that("sampling before a simulation start (backward)", {
   expect_error(sampling(model, time = 1005, list(p1, 3), strict = TRUE), msg) # pre-split
   expect_error(sampling(model, time = 10, list(p1, 3), strict = TRUE), msg) # post-removal
 })
+
+test_that("sampling in the same generation of the split is prevented (forward)", {
+  p1 <- population(name = "p1", time = 1, N = 1, remove = 50)
+  model <- compile(populations = p1, dir = tempdir(), generation_time = 25, sim_length = 100, overwrite = TRUE)
+  expect_warning(sampling(model, time = 3, list(p1, 3)), "No valid sampling")
+})
+
+test_that("sampling in the same generation of the split is prevented (backward)", {
+  p1 <- population(name = "p1", time = 100, N = 1, remove = 10)
+  model <- compile(populations = p1, dir = tempdir(), generation_time = 25, overwrite = TRUE)
+  expect_warning(sampling(model, time = 97, list(p1, 3)), "No valid sampling")
+})


### PR DESCRIPTION
This fixes two issues reported in #69:

- The `sampling()` function is now smarter in handling cases where individuals are being scheduled for sampling at the effectively in the same generation as their population is being created. For instance, this can arise when these two events (given as time in years) "collapse" to a single generation in SLiM.

- Sometimes (very rarely!) an individual was scheduled for sampling twice. This lead to the final tree sequence having one less individual then requested by the user via the `sampling()` call, leading to crashes when `ts_load`-ing the data.

Here is a small test case provided by @moicoll which first reported these issues. The R package can now correctly deal with those problems.

These issues are very complex, and even more so because _slendr_ allows flexible time specification in forward and in backward direction which complicates the sanity checks quite a lot. However, I'll close the issue for now and wait for other bugs to pop up.

```
# fetch the latest slendr version with the bugfixes implemented
devtools::install_github("bodkan/slendr")

library(slendr)

set.seed(1234)

# this links to my Python setup -- you might do something else
reticulate::use_condaenv("retipy", required = TRUE)
reticulate::py_config()

map <- world(xrange = c(-15, 60), yrange = c(20, 65),crs = "EPSG:3035")

africa   <- region("Africa",   map, polygon = list(c(-18, 20), c(40, 20), c(30, 33),c(20, 32), c(10, 35), c(-8, 35)))
europe   <- region("Europe",   map, polygon = list(c(-8, 35), c(-5, 36), c(10, 38), c(20, 35), c(25, 35),c(33, 45), c(20, 58), c(-5, 60), c(-15, 50)))
anatolia <- region("Anatolia", map, polygon = list(c(28, 35), c(40, 35), c(42, 40), c(30, 43), c(27, 40), c(25, 38)))

afr <- population("AFR", parent = "ancestor", time = 52000, N = 3000, map = map, polygon = africa)
ooa <- population("OOA", parent = afr, time = 51000, N = 500, remove = 25000, center = c(33, 30), radius = 400e3) %>%
  move(trajectory = list(c(40, 30), c(50, 30), c(60, 40)), start = 50000, end = 40000, snapshots = 20)
ehg <- population("EHG", parent = ooa, time = 28000, N = 1000, remove = 6000, polygon = list(c(26, 55), c(38, 53), c(48, 53), c(60, 53), c(60, 60), c(48, 63), c(38, 63), c(26, 60)))
eur <- population( name = "EUR", parent = ehg, time = 25000, N = 2000, polygon = europe)
ana <- population( name = "ANA", time = 28000, N = 3000, parent = ooa, remove = 4000, center = c(34, 38), radius = 500e3, polygon = anatolia) %>%
  expand(by = 2500e3, start = 10000, end = 7000, polygon = join(europe, anatolia), snapshots = 20)
yam <- population( name = "YAM", time = 7000, N = 500, parent = ehg, remove = 2500, polygon = list(c(26, 50), c(38, 49), c(48, 50), c(48, 56), c(38, 59), c(26, 56))) %>%
  move(trajectory = list(c(15, 50)), start = 5000, end = 3000, snapshots = 10)

gf <- list(
  geneflow(from = ana, to = yam, rate = 0.5,  start = 6500, end = 6400, overlap = FALSE),
  geneflow(from = ana, to = eur, rate = 0.5,  start = 8000, end = 6000),
  geneflow(from = yam, to = eur, rate = 0.75, start = 4000, end = 3000))

model <- compile(
  populations      = list(afr, ooa, ehg, eur, ana, yam),
  geneflow         = gf,
  generation_time  = 30,
  resolution       = 10e3,
  competition_dist = 130e3, mate_dist = 100e3,
  dispersal_dist   = 70e3,
  dir              = "~/Desktop/moi-model", overwrite = TRUE)

samples1 <- slendr::sampling(
  model, times = runif(n = 1000, min = 2500, max = 52000),
  list(afr, 1), list(ooa, 1), list(ehg, 1), list(eur, 1), list(ana, 1)
)

print(paste("Nº of samples : ", sum(samples1$n), sep = ""))
samples1 %>% summary() %>% print()

# this no longer crashes because the sampling events inconsistent with
# population split times are now handled by `sampling()` internally
slendr::slim(model,
             sequence_length    = 1,
             recombination_rate = 0,
             sampling           = samples1,
             verbose            = TRUE,
             save_locations     = TRUE,
             method             = "batch",
             seed               = 1234,
             save_sampling      = TRUE)

# we no longer have the issue by some individuals gone missing, breaking
# the loading of tables of individuals
ts <- ts_load(model, recapitate = TRUE, simplify = TRUE,
              Ne = 10000, recombination_rate = 0)

# verify we get the same number of samples from the tree sequence
ts_samples(ts) %>% nrow()
```