### PR TITLE
Spatial sampling

### DIFF
--- a/R/compilation.R
+++ b/R/compilation.R
@@ -323,7 +323,8 @@ slim <- function(model, sequence_length, recombination_rate,
   burnin <- round(burnin / model$generation_time)
 
   sampling_path <- ifelse(save_sampling, paste0(output, "_sampling.tsv"), tempfile())
-  process_sampling(sampling, model, sampling_path, verbose)
+  sampling_df <- process_sampling(sampling, model, verbose)
+  readr::write_tsv(sampling_df, sampling_path)
 
   binary <- if (!is.null(slim_path)) slim_path else get_binary(method)
   seed <- if (is.null(seed)) "" else paste0(" \\\n    -d SEED=", seed)

--- a/R/interface.R
+++ b/R/interface.R
@@ -732,8 +732,8 @@ reproject <- function(from, to, x = NULL, y = NULL, coords = NULL, model = NULL,
     colnames(new_point) <- c(outx, outy)
   }
 
-  if (nrow(new_point) == 1)
-    return(as.vector(unlist(new_point)))
+  # if (nrow(new_point) == 1)
+  #   return(as.vector(unlist(new_point)))
 
   if (add) new_point <- cbind(coords, new_point) %>% dplyr::as_tibble()
 
@@ -1010,7 +1010,7 @@ sampling <- function(model, times, ..., locations = NULL, strict = FALSE) {
   }
 
   if (!is.null(locations)) {
-    check_location_bounds(locations, map)
+    check_location_bounds(locations, model$world)
 
     # convert the list of coordinate pairs into a data frame with x and y
     # columns transformed from world-based coordinates into raster-based

--- a/R/interface.R
+++ b/R/interface.R
@@ -917,14 +917,18 @@ dimensions <- function(map, original = FALSE) {
 
 #' Define sampling events for a given set of populations
 #'
-#' Schedule sampling events at specified times and, optionally, locations on a
-#' landscape
+#' Schedule sampling events at specified times and, optionally, a given set of
+#' locations on a landscape
 #'
 #' If both times and locations are given, the the sampling will be scheduled on
 #' each specified location in each given time-point. Note that for the
 #' time-being, in the interest of simplicity, no sanity checks are performed on
-#' the locations given. The R package will simply instruct SLiM to sample given
-#' individuals as close to the sampling points given as possible.
+#' the locations given except the restriction that the sampling points must fall
+#' within the bounding box around the simulated world map. Other than that,
+#' slendr will simply instruct its SLiM backend script to sample individuals as
+#' close to the sampling points given as possible, regardless of whethere those
+#' points lie within a population spatial boundary at that particular moment of
+#' time.
 #'
 #' @param model Object of the class \code{slendr_model}
 #' @param times Integer vector of times (in model time units) at which to

--- a/R/utils.R
+++ b/R/utils.R
@@ -381,6 +381,20 @@ process_sampling <- function(samples, model, sampling_path, verbose) {
   readr::write_tsv(df, sampling_path)
 }
 
+# Make sure all given locations fall within world bounding box
+check_location_bounds <- function(locations, map) {
+  xrange <- attr(map, "xrange")
+  yrange <- attr(map, "yrange")
+
+  checks <- sapply(locations, function(loc) {
+    loc[1] >= xrange[1] & loc[1] <= xrange[2] &
+    loc[2] >= yrange[1] & loc[2] <= yrange[2]
+  })
+
+  if (!all(checks))
+    stop("The following locations fall outside of the world map: ",
+         paste(locations[!checks], collapse = ", "), call. = FALSE)
+}
 
 #' Pipe operator
 #'

--- a/README.md
+++ b/README.md
@@ -236,9 +236,9 @@ slim(
 #> 
 #> /usr/local/bin/slim  \
 #>     -d SEED=314159  \
-#>     -d 'SAMPLES="/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//Rtmp85i4q9/file168538bc8ff7"' \
-#>     -d 'MODEL="/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//Rtmp85i4q9/readme-model"' \
-#>     -d 'OUTPUT="/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//Rtmp85i4q9/readme-model/output"' \
+#>     -d 'SAMPLES="/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//RtmppDlA4i/fileaae46162565c"' \
+#>     -d 'MODEL="/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//RtmppDlA4i/readme-model"' \
+#>     -d 'OUTPUT="/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//RtmppDlA4i/readme-model/output"' \
 #>     -d SPATIAL=T \
 #>     -d SEQUENCE_LENGTH=1 \
 #>     -d RECOMB_RATE=0 \
@@ -246,7 +246,7 @@ slim(
 #>     -d SIMULATION_LENGTH=1733 \
 #>     -d SAVE_LOCATIONS=T \
 #>     -d MAX_ATTEMPTS=10 \
-#>     /var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//Rtmp85i4q9/readme-model/script.slim 
+#>     /var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//RtmppDlA4i/readme-model/script.slim 
 #> --------------------------------------------------
 ```
 

--- a/docs/articles/vignette-01-tutorial.html
+++ b/docs/articles/vignette-01-tutorial.html
@@ -200,7 +200,7 @@
   crs <span class="op">=</span> <span class="st">"EPSG:3035"</span>    <span class="co"># projected CRS used internally</span>
 <span class="op">)</span></code></pre></div>
 <pre><code>#&gt; OGR data source with driver: ESRI Shapefile 
-#&gt; Source: "/private/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T/RtmpCkOEZt", layer: "ne_110m_land"
+#&gt; Source: "/private/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T/Rtmp4UrTM1", layer: "ne_110m_land"
 #&gt; with 127 features
 #&gt; It has 3 fields</code></pre>
 <p>Internally, the <code>map</code> object is currently a normal <code>sf</code> class object without additional components. This is unlike other <code>slendr</code> objects described below, which are also <code>sf</code> objects but which carry additional internal components.</p>
@@ -598,9 +598,9 @@ between populations.</code></pre>
 #&gt; 
 #&gt; /usr/local/bin/slim  \
 #&gt;     -d SEED=314159  \
-#&gt;     -d 'SAMPLES="/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//RtmpCkOEZt/file175f178a53fd"' \
-#&gt;     -d 'MODEL="/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//RtmpCkOEZt/tutorial-model"' \
-#&gt;     -d 'OUTPUT="/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//RtmpCkOEZt/tutorial-model/output"' \
+#&gt;     -d 'SAMPLES="/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//Rtmp4UrTM1/fileaccf2749a348"' \
+#&gt;     -d 'MODEL="/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//Rtmp4UrTM1/tutorial-model"' \
+#&gt;     -d 'OUTPUT="/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//Rtmp4UrTM1/tutorial-model/output"' \
 #&gt;     -d SPATIAL=T \
 #&gt;     -d SEQUENCE_LENGTH=1 \
 #&gt;     -d RECOMB_RATE=0 \
@@ -608,7 +608,7 @@ between populations.</code></pre>
 #&gt;     -d SIMULATION_LENGTH=1733 \
 #&gt;     -d SAVE_LOCATIONS=T \
 #&gt;     -d MAX_ATTEMPTS=10 \
-#&gt;     /var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//RtmpCkOEZt/tutorial-model/script.slim 
+#&gt;     /var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//Rtmp4UrTM1/tutorial-model/script.slim 
 #&gt; --------------------------------------------------</code></pre>
 <p>By default, simulation output files are put in the same directory where the model configuration data is stored, and are given a common prefix <code>output_</code>. Both the directory and the output file prefix can be specified by setting the <code>output_dir</code> and <code>output_prefix</code> arguments of the function <code><a href="../reference/slim.html">slim()</a></code>.</p>
 </div>

--- a/docs/articles/vignette-02-grid-model.html
+++ b/docs/articles/vignette-02-grid-model.html
@@ -257,7 +257,7 @@
   crs <span class="op">=</span> <span class="fl">4326</span>
 <span class="op">)</span></code></pre></div>
 <pre><code>#&gt; OGR data source with driver: ESRI Shapefile 
-#&gt; Source: "/private/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T/RtmpJ7UF1d", layer: "ne_110m_land"
+#&gt; Source: "/private/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T/RtmpFvGiiu", layer: "ne_110m_land"
 #&gt; with 127 features
 #&gt; It has 3 fields</code></pre>
 <div class="sourceCode" id="cb17"><pre class="downlit sourceCode r">

--- a/docs/articles/vignette-03-interactions.html
+++ b/docs/articles/vignette-03-interactions.html
@@ -191,9 +191,9 @@
 #&gt; 
 #&gt; /usr/local/bin/slim  \
 #&gt;     -d SEED=314159  \
-#&gt;     -d 'SAMPLES="/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//RtmpJQ8FqZ/file182a237acea9"' \
-#&gt;     -d 'MODEL="/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//RtmpJQ8FqZ/spatial-interactions"' \
-#&gt;     -d 'OUTPUT="/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//RtmpJQ8FqZ/spatial-interactions/output"' \
+#&gt;     -d 'SAMPLES="/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//RtmpMVT2hM/fileaee7657fdbef"' \
+#&gt;     -d 'MODEL="/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//RtmpMVT2hM/spatial-interactions"' \
+#&gt;     -d 'OUTPUT="/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//RtmpMVT2hM/spatial-interactions/output"' \
 #&gt;     -d SPATIAL=T \
 #&gt;     -d SEQUENCE_LENGTH=1 \
 #&gt;     -d RECOMB_RATE=0 \
@@ -201,7 +201,7 @@
 #&gt;     -d SIMULATION_LENGTH=1000 \
 #&gt;     -d SAVE_LOCATIONS=T \
 #&gt;     -d MAX_ATTEMPTS=10 \
-#&gt;     /var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//RtmpJQ8FqZ/spatial-interactions/script.slim 
+#&gt;     /var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//RtmpMVT2hM/spatial-interactions/script.slim 
 #&gt; --------------------------------------------------</code></pre>
 <p>Once the simulation has finished running, we can recapitulate the spatial population dynamics simulated by the SLiM back end script as an animated GIF:</p>
 <div class="sourceCode" id="cb9"><pre class="downlit sourceCode r">

--- a/docs/articles/vignette-05-tree-sequences.html
+++ b/docs/articles/vignette-05-tree-sequences.html
@@ -176,39 +176,39 @@
 <div class="sourceCode" id="cb3"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span class="va">nea_samples</span> <span class="op">&lt;-</span> <span class="fu"><a href="../reference/sampling.html">sampling</a></span><span class="op">(</span><span class="va">model</span>, times <span class="op">=</span> <span class="fu"><a href="https://rdrr.io/r/base/c.html">c</a></span><span class="op">(</span><span class="fl">70000</span>, <span class="fl">40000</span><span class="op">)</span>, <span class="fu"><a href="https://rdrr.io/r/base/list.html">list</a></span><span class="op">(</span><span class="va">nea</span>, <span class="fl">1</span><span class="op">)</span><span class="op">)</span>
 <span class="va">nea_samples</span></code></pre></div>
-<pre><code>#&gt; # A tibble: 2 × 3
-#&gt;    time pop       n
-#&gt;   &lt;int&gt; &lt;chr&gt; &lt;int&gt;
-#&gt; 1 40000 NEA       1
-#&gt; 2 70000 NEA       1</code></pre>
+<pre><code>#&gt; # A tibble: 2 × 7
+#&gt;    time pop       n y_orig x_orig y     x    
+#&gt;   &lt;int&gt; &lt;chr&gt; &lt;int&gt; &lt;lgl&gt;  &lt;lgl&gt;  &lt;lgl&gt; &lt;lgl&gt;
+#&gt; 1 40000 NEA       1 NA     NA     NA    NA   
+#&gt; 2 70000 NEA       1 NA     NA     NA    NA</code></pre>
 <p>As you can see, the <code><a href="../reference/sampling.html">sampling()</a></code> function simply accepts the vector of times at which remembering should be schedule, and then a list of pairs <code>(&lt;slendr population&gt;, &lt;number of individuals&gt;)</code> encoding from which populations should how many individuals be remembered at time points given in the <code>times</code> vector.</p>
 <p>Next, we want to sample some present-day individuals: an outgroup representing a chimpanzee, and a couple of Africans and Europeans:</p>
 <div class="sourceCode" id="cb5"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span class="va">present_samples</span> <span class="op">&lt;-</span> <span class="fu"><a href="../reference/sampling.html">sampling</a></span><span class="op">(</span><span class="va">model</span>, times <span class="op">=</span> <span class="fl">0</span>, <span class="fu"><a href="https://rdrr.io/r/base/list.html">list</a></span><span class="op">(</span><span class="va">chimp</span>, <span class="fl">1</span><span class="op">)</span>, <span class="fu"><a href="https://rdrr.io/r/base/list.html">list</a></span><span class="op">(</span><span class="va">afr</span>, <span class="fl">5</span><span class="op">)</span>, <span class="fu"><a href="https://rdrr.io/r/base/list.html">list</a></span><span class="op">(</span><span class="va">eur</span>, <span class="fl">10</span><span class="op">)</span><span class="op">)</span>
 <span class="va">present_samples</span></code></pre></div>
-<pre><code>#&gt; # A tibble: 3 × 3
-#&gt;    time pop       n
-#&gt;   &lt;int&gt; &lt;chr&gt; &lt;int&gt;
-#&gt; 1     0 CH        1
-#&gt; 2     0 AFR       5
-#&gt; 3     0 EUR      10</code></pre>
+<pre><code>#&gt; # A tibble: 3 × 7
+#&gt;    time pop       n y_orig x_orig y     x    
+#&gt;   &lt;int&gt; &lt;chr&gt; &lt;int&gt; &lt;lgl&gt;  &lt;lgl&gt;  &lt;lgl&gt; &lt;lgl&gt;
+#&gt; 1     0 CH        1 NA     NA     NA    NA   
+#&gt; 2     0 AFR       5 NA     NA     NA    NA   
+#&gt; 3     0 EUR      10 NA     NA     NA    NA</code></pre>
 <p>As you can see above, the <code><a href="../reference/sampling.html">sampling()</a></code> function returns a plain old data frame with a very simple structure with three columns: time, population name, and the number of individuals. This means that you can define sampling events using whatever input data you might already have available (such as radiocarbon-dated ancient DNA samples from an Excel sheet from some publication). For instance, there has been a <a href="https://www.nature.com/articles/nature17993">lot</a> of <a href="https://www.pnas.org/content/116/5/1639">interest</a> to estimate the trajectory of Neanderthal ancestry in Europe over time using ancient DNA data from anatomically modern human individuals (also called early modern humans, EMH) across the last couple of tens of thousands of years. We can simulate something close to the available <a href="https://www.nature.com/articles/nature17993">EMH ancient DNA data set</a> over the last 50 thousand years by running doing this:</p>
 <div class="sourceCode" id="cb7"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span class="va">emh_samples</span> <span class="op">&lt;-</span> <span class="fu"><a href="../reference/sampling.html">sampling</a></span><span class="op">(</span><span class="va">model</span>, times <span class="op">=</span> <span class="fu"><a href="https://rdrr.io/r/stats/Uniform.html">runif</a></span><span class="op">(</span>n <span class="op">=</span> <span class="fl">40</span>, min <span class="op">=</span> <span class="fl">10000</span>, max <span class="op">=</span> <span class="fl">40000</span><span class="op">)</span>, <span class="fu"><a href="https://rdrr.io/r/base/list.html">list</a></span><span class="op">(</span><span class="va">eur</span>, <span class="fl">1</span><span class="op">)</span><span class="op">)</span>
 <span class="va">emh_samples</span></code></pre></div>
-<pre><code>#&gt; # A tibble: 40 × 3
-#&gt;     time pop       n
-#&gt;    &lt;int&gt; &lt;chr&gt; &lt;int&gt;
-#&gt;  1 10319 EUR       1
-#&gt;  2 11187 EUR       1
-#&gt;  3 11395 EUR       1
-#&gt;  4 11529 EUR       1
-#&gt;  5 11927 EUR       1
-#&gt;  6 12675 EUR       1
-#&gt;  7 13689 EUR       1
-#&gt;  8 13744 EUR       1
-#&gt;  9 14774 EUR       1
-#&gt; 10 16361 EUR       1
+<pre><code>#&gt; # A tibble: 40 × 7
+#&gt;     time pop       n y_orig x_orig y     x    
+#&gt;    &lt;int&gt; &lt;chr&gt; &lt;int&gt; &lt;lgl&gt;  &lt;lgl&gt;  &lt;lgl&gt; &lt;lgl&gt;
+#&gt;  1 10319 EUR       1 NA     NA     NA    NA   
+#&gt;  2 11187 EUR       1 NA     NA     NA    NA   
+#&gt;  3 11395 EUR       1 NA     NA     NA    NA   
+#&gt;  4 11529 EUR       1 NA     NA     NA    NA   
+#&gt;  5 11927 EUR       1 NA     NA     NA    NA   
+#&gt;  6 12675 EUR       1 NA     NA     NA    NA   
+#&gt;  7 13689 EUR       1 NA     NA     NA    NA   
+#&gt;  8 13744 EUR       1 NA     NA     NA    NA   
+#&gt;  9 14774 EUR       1 NA     NA     NA    NA   
+#&gt; 10 16361 EUR       1 NA     NA     NA    NA   
 #&gt; # … with 30 more rows</code></pre>
 <p>This samples a single ancient European individuals at randomly chosen times between 40 and 10 ky ago.</p>
 <p>One nice feature of the <code><a href="../reference/sampling.html">sampling()</a></code> function is that it only schedules sampling events for a population, if that population is present in the simulation at a given time. This makes it possible to simply take a wide time range for sampling, specify all populations and sizes of the samples, and let the function generate sampling events only for populations present at each time. If for some reason a stricter control over sampling is required, this behavior can be switched off by setting <code>strict = TRUE</code> like this:</p>
@@ -229,9 +229,9 @@
 #&gt; 
 #&gt; /usr/local/bin/slim  \
 #&gt;     -d SEED=314159  \
-#&gt;     -d 'SAMPLES="/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//RtmpgXWavv/file18f229f8466"' \
-#&gt;     -d 'MODEL="/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//RtmpgXWavv/introgression"' \
-#&gt;     -d 'OUTPUT="/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//RtmpgXWavv/introgression/output"' \
+#&gt;     -d 'SAMPLES="/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//RtmpcXzudM/fileb2fe2e3f1389"' \
+#&gt;     -d 'MODEL="/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//RtmpcXzudM/introgression"' \
+#&gt;     -d 'OUTPUT="/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//RtmpcXzudM/introgression/output"' \
 #&gt;     -d SPATIAL=F \
 #&gt;     -d SEQUENCE_LENGTH=10000000 \
 #&gt;     -d RECOMB_RATE=1e-08 \
@@ -239,7 +239,7 @@
 #&gt;     -d SIMULATION_LENGTH=216667 \
 #&gt;     -d SAVE_LOCATIONS=F \
 #&gt;     -d MAX_ATTEMPTS=10 \
-#&gt;     /var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//RtmpgXWavv/introgression/script.slim 
+#&gt;     /var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//RtmpcXzudM/introgression/script.slim 
 #&gt; --------------------------------------------------</code></pre>
 </div>
 <div id="r-interface-for-tskit-and-pyslim" class="section level2">
@@ -315,7 +315,7 @@
 #&gt; ╟───────────┼──────┼────────┼────────────╢
 #&gt; ║Populations│     5│ 3.1 KiB│         Yes║
 #&gt; ╟───────────┼──────┼────────┼────────────╢
-#&gt; ║Provenances│     1│30.0 KiB│          No║
+#&gt; ║Provenances│     1│30.5 KiB│          No║
 #&gt; ╟───────────┼──────┼────────┼────────────╢
 #&gt; ║Sites      │     0│ 8 Bytes│          No║
 #&gt; ╚═══════════╧══════╧════════╧════════════╝</code></pre>
@@ -352,7 +352,7 @@
 #&gt; ╟───────────┼─────┼─────────┼────────────╢
 #&gt; ║Populations│    5│  3.1 KiB│         Yes║
 #&gt; ╟───────────┼─────┼─────────┼────────────╢
-#&gt; ║Provenances│    2│ 30.5 KiB│          No║
+#&gt; ║Provenances│    2│ 31.0 KiB│          No║
 #&gt; ╟───────────┼─────┼─────────┼────────────╢
 #&gt; ║Sites      │    0│  8 Bytes│          No║
 #&gt; ╚═══════════╧═════╧═════════╧════════════╝</code></pre>
@@ -389,7 +389,7 @@
 #&gt; ╟───────────┼─────┼─────────┼────────────╢
 #&gt; ║Populations│    5│  3.1 KiB│         Yes║
 #&gt; ╟───────────┼─────┼─────────┼────────────╢
-#&gt; ║Provenances│    3│ 31.0 KiB│          No║
+#&gt; ║Provenances│    3│ 31.5 KiB│          No║
 #&gt; ╟───────────┼─────┼─────────┼────────────╢
 #&gt; ║Sites      │    0│  8 Bytes│          No║
 #&gt; ╚═══════════╧═════╧═════════╧════════════╝</code></pre>
@@ -431,7 +431,7 @@
 #&gt; ╟───────────┼─────┼─────────┼────────────╢
 #&gt; ║Populations│    5│  3.1 KiB│         Yes║
 #&gt; ╟───────────┼─────┼─────────┼────────────╢
-#&gt; ║Provenances│    3│ 31.3 KiB│          No║
+#&gt; ║Provenances│    3│ 31.7 KiB│          No║
 #&gt; ╟───────────┼─────┼─────────┼────────────╢
 #&gt; ║Sites      │58089│964.4 KiB│          No║
 #&gt; ╚═══════════╧═════╧═════════╧════════════╝</code></pre>

--- a/docs/articles/vignette-06-locations.html
+++ b/docs/articles/vignette-06-locations.html
@@ -161,7 +161,7 @@
   crs <span class="op">=</span> <span class="st">"EPSG:3035"</span>
 <span class="op">)</span></code></pre></div>
 <pre><code>#&gt; OGR data source with driver: ESRI Shapefile 
-#&gt; Source: "/private/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T/RtmpXIfmrf", layer: "ne_110m_land"
+#&gt; Source: "/private/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T/RtmphhLFxN", layer: "ne_110m_land"
 #&gt; with 127 features
 #&gt; It has 3 fields</code></pre>
 <div class="sourceCode" id="cb4"><pre class="downlit sourceCode r">
@@ -274,9 +274,9 @@
 #&gt; 
 #&gt; /usr/local/bin/slim  \
 #&gt;     -d SEED=314159  \
-#&gt;     -d 'SAMPLES="/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//RtmpXIfmrf/file1eb3527a74ae"' \
-#&gt;     -d 'MODEL="/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//RtmpXIfmrf/spatial-ts"' \
-#&gt;     -d 'OUTPUT="/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//RtmpXIfmrf/spatial-ts/output"' \
+#&gt;     -d 'SAMPLES="/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//RtmphhLFxN/fileb662301b6c68"' \
+#&gt;     -d 'MODEL="/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//RtmphhLFxN/spatial-ts"' \
+#&gt;     -d 'OUTPUT="/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//RtmphhLFxN/spatial-ts/output"' \
 #&gt;     -d SPATIAL=T \
 #&gt;     -d SEQUENCE_LENGTH=100000 \
 #&gt;     -d RECOMB_RATE=1e-08 \
@@ -284,7 +284,7 @@
 #&gt;     -d SIMULATION_LENGTH=1733 \
 #&gt;     -d SAVE_LOCATIONS=F \
 #&gt;     -d MAX_ATTEMPTS=1 \
-#&gt;     /var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//RtmpXIfmrf/spatial-ts/script.slim 
+#&gt;     /var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//RtmphhLFxN/spatial-ts/script.slim 
 #&gt; --------------------------------------------------</code></pre>
 <p>After the simulation is done, we can load the data in the same way we did in our <a href="vignette-05-tree%20sequences.html#loading-and-processing-tree%20sequence-output-files-1">first exploration</a> of tree sequence features in <em>slendr</em>. We will also immediately simplify the tree sequence data structure to only those genealogies which involve individuals that we explicitly scheduled for sampling, and perform recapitation to ensure the coalescence of all genealogies along the genome:</p>
 <div class="sourceCode" id="cb11"><pre class="downlit sourceCode r">
@@ -321,7 +321,7 @@
 #&gt; oldest sampled individual: 40000 backward time units
 #&gt; youngest sampled individual: 0 backward time units
 #&gt; 
-#&gt; oldest node: 2192941 backward time units
+#&gt; oldest node: 2281375 backward time units
 #&gt; youngest node: 0 backward time units
 #&gt; ---------------------- 
 #&gt; contents of the underlying sf object:
@@ -341,7 +341,7 @@
 #&gt; 5  TRUE    31383200
 #&gt; 6  TRUE    31383200
 #&gt; 
-#&gt; ... and 560 additional rows
+#&gt; ... and 561 additional rows
 #&gt; ---------------------- 
 #&gt; map: internal coordinate reference system EPSG 3035 
 #&gt; spatial limits (in degrees longitude and latitude):
@@ -350,7 +350,7 @@
 <p>In the first part of the summary, we see how many individuals (sampled or retained) and nodes are present in the tree sequence together with additional useful information, including a section of the internally stored <code>sf</code> object. And this is a crucial point—<strong>we can always access the internal <code>sf</code> object with the spatial data</strong> by running the following, which avoid the verbose summary above and exposes the underlying <a href="https://r-spatial.github.io/sf/articles/sf1.html#how-simple-features-in-r-are-organized-1"><em>sf</em> data frame</a> directly:</p>
 <div class="sourceCode" id="cb17"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span class="va">data</span><span class="op">[</span><span class="op">]</span></code></pre></div>
-<pre><code>#&gt; Simple feature collection with 566 features and 9 fields (with 9 geometries empty)
+<pre><code>#&gt; Simple feature collection with 567 features and 9 fields (with 10 geometries empty)
 #&gt; Geometry type: POINT
 #&gt; Dimension:     XY
 #&gt; Bounding box:  xmin: 2364888 ymin: 294002.8 xmax: 8577345 ymax: 4763638
@@ -371,7 +371,7 @@
 #&gt; oldest sampled individual: 40000 backward time units
 #&gt; youngest sampled individual: 0 backward time units
 #&gt; 
-#&gt; oldest node: 2192941 backward time units
+#&gt; oldest node: 2281375 backward time units
 #&gt; youngest node: 0 backward time units
 #&gt; ---------------------- 
 #&gt; contents of the underlying sf object:
@@ -391,7 +391,7 @@
 #&gt; 5  TRUE    31383200
 #&gt; 6  TRUE    31383200
 #&gt; 
-#&gt; ... and 560 additional rows
+#&gt; ... and 561 additional rows
 #&gt; ---------------------- 
 #&gt; map: internal coordinate reference system EPSG 3035 
 #&gt; spatial limits (in degrees longitude and latitude):

--- a/docs/index.html
+++ b/docs/index.html
@@ -326,9 +326,9 @@
 <span class="co">#&gt; </span>
 <span class="co">#&gt; /usr/local/bin/slim  \</span>
 <span class="co">#&gt;     -d SEED=314159  \</span>
-<span class="co">#&gt;     -d 'SAMPLES="/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//Rtmp85i4q9/file168538bc8ff7"' \</span>
-<span class="co">#&gt;     -d 'MODEL="/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//Rtmp85i4q9/readme-model"' \</span>
-<span class="co">#&gt;     -d 'OUTPUT="/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//Rtmp85i4q9/readme-model/output"' \</span>
+<span class="co">#&gt;     -d 'SAMPLES="/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//RtmppDlA4i/fileaae46162565c"' \</span>
+<span class="co">#&gt;     -d 'MODEL="/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//RtmppDlA4i/readme-model"' \</span>
+<span class="co">#&gt;     -d 'OUTPUT="/var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//RtmppDlA4i/readme-model/output"' \</span>
 <span class="co">#&gt;     -d SPATIAL=T \</span>
 <span class="co">#&gt;     -d SEQUENCE_LENGTH=1 \</span>
 <span class="co">#&gt;     -d RECOMB_RATE=0 \</span>
@@ -336,7 +336,7 @@
 <span class="co">#&gt;     -d SIMULATION_LENGTH=1733 \</span>
 <span class="co">#&gt;     -d SAVE_LOCATIONS=T \</span>
 <span class="co">#&gt;     -d MAX_ATTEMPTS=10 \</span>
-<span class="co">#&gt;     /var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//Rtmp85i4q9/readme-model/script.slim </span>
+<span class="co">#&gt;     /var/folders/hr/_t1b0f5n7c76yrfsg8yk9l100000gn/T//RtmppDlA4i/readme-model/script.slim </span>
 <span class="co">#&gt; --------------------------------------------------</span></code></pre></div>
 <p>As specified, the SLiM run will save ancestry proportions in each population over time as well as the location of every individual who ever lived.</p>
 </div>

--- a/docs/pkgdown.yml
+++ b/docs/pkgdown.yml
@@ -1,4 +1,4 @@
-pandoc: '2.13'
+pandoc: 2.16.2
 pkgdown: 1.6.1
 pkgdown_sha: ~
 articles:
@@ -10,7 +10,7 @@ articles:
   vignette-06-locations: vignette-06-locations.html
   vignette-07-msprime: vignette-07-msprime.html
   vignette-08-paper: vignette-08-paper.html
-last_built: 2021-12-06T10:18Z
+last_built: 2021-12-08T12:29Z
 urls:
   reference: https://www.slendr.net/reference
   article: https://www.slendr.net/articles

--- a/docs/reference/index.html
+++ b/docs/reference/index.html
@@ -399,7 +399,7 @@
         <td>
           <p><code><a href="sampling.html">sampling()</a></code> </p>
         </td>
-        <td><p>Define sampling events at specified times for a given set of populations</p></td>
+        <td><p>Define sampling events for a given set of populations</p></td>
       </tr><tr>
         
         <td>

--- a/docs/reference/sampling.html
+++ b/docs/reference/sampling.html
@@ -6,7 +6,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title>Define sampling events at specified times for a given set of populations — sampling • slendr</title>
+<title>Define sampling events for a given set of populations — sampling • slendr</title>
 
 <!-- favicons -->
 <link rel="icon" type="image/png" sizes="16x16" href="../favicon-16x16.png">
@@ -52,8 +52,9 @@
 
 
 
-<meta property="og:title" content="Define sampling events at specified times for a given set of populations — sampling" />
-<meta property="og:description" content="Define sampling events at specified times for a given set of populations" />
+<meta property="og:title" content="Define sampling events for a given set of populations — sampling" />
+<meta property="og:description" content="Schedule sampling events at specified times and, optionally, a given set of
+locations on a landscape" />
 <meta property="og:image" content="https://www.slendr.net/logo.png" />
 
 
@@ -170,16 +171,17 @@
 <div class="row">
   <div class="col-md-9 contents">
     <div class="page-header">
-    <h1>Define sampling events at specified times for a given set of populations</h1>
+    <h1>Define sampling events for a given set of populations</h1>
     <small class="dont-index">Source: <a href='https://github.com/bodkan/slendr/blob/master/R/interface.R'><code>R/interface.R</code></a></small>
     <div class="hidden name"><code>sampling.Rd</code></div>
     </div>
 
     <div class="ref-description">
-    <p>Define sampling events at specified times for a given set of populations</p>
+    <p>Schedule sampling events at specified times and, optionally, a given set of
+locations on a landscape</p>
     </div>
 
-    <pre class="usage"><span class='fu'>sampling</span><span class='op'>(</span><span class='va'>model</span>, <span class='va'>times</span>, <span class='va'>...</span>, strict <span class='op'>=</span> <span class='cn'>FALSE</span><span class='op'>)</span></pre>
+    <pre class="usage"><span class='fu'>sampling</span><span class='op'>(</span><span class='va'>model</span>, <span class='va'>times</span>, <span class='va'>...</span>, locations <span class='op'>=</span> <span class='cn'>NULL</span>, strict <span class='op'>=</span> <span class='cn'>FALSE</span><span class='op'>)</span></pre>
 
     <h2 class="hasAnchor" id="arguments"><a class="anchor" href="#arguments"></a>Arguments</h2>
     <table class="ref-arguments">
@@ -200,17 +202,39 @@ of individuals to sample), representing from which populations should how
 many individuals be remembered at times given by <code>times</code></p></td>
     </tr>
     <tr>
+      <th>locations</th>
+      <td><p>List of vector pairs, defining two-dimensional coordinates
+of locations at which the closest number of individuals from given
+populations should be sampled. If <code>NULL</code> (the default), individuals
+will be sampled randomly throughout their spatial boundary.</p></td>
+    </tr>
+    <tr>
       <th>strict</th>
       <td><p>Should any occurence of a population not being present at a
-given time result in an error? Default is <code>FALSE</code>, meaning that invalid
-sampling times for any populations will be quietly ignored.</p></td>
+given time result in an error? Default is <code>FALSE</code>, meaning that
+invalid sampling times for any populations will be quietly ignored.</p></td>
+    </tr>
+    <tr>
+      <th>remove</th>
+      <td><p>Time at which the population should be removed</p></td>
     </tr>
     </table>
 
     <h2 class="hasAnchor" id="value"><a class="anchor" href="#value"></a>Value</h2>
 
-    <p>Data frame with three columns: time of sampling, population
-to sample from, how many individuals to sample</p>
+    <p>Data frame with three columns: time of sampling, population to sample
+from, how many individuals to sample</p>
+    <h2 class="hasAnchor" id="details"><a class="anchor" href="#details"></a>Details</h2>
+
+    <p>If both times and locations are given, the the sampling will be scheduled on
+each specified location in each given time-point. Note that for the
+time-being, in the interest of simplicity, no sanity checks are performed on
+the locations given except the restriction that the sampling points must fall
+within the bounding box around the simulated world map. Other than that,
+slendr will simply instruct its SLiM backend script to sample individuals as
+close to the sampling points given as possible, regardless of whethere those
+points lie within a population spatial boundary at that particular moment of
+time.</p>
 
   </div>
   <div class="col-md-3 hidden-xs hidden-sm" id="pkgdown-sidebar">

--- a/inst/extdata/script.slim
+++ b/inst/extdata/script.slim
@@ -346,8 +346,12 @@ s10 late() /* Remember individuals for tree sequence recording */ {
         all_inds = all_inds[all_inds.tag != 1];
 
         x = event.getValue("x"); y = event.getValue("y");
-        if (x != -1 & y != -1)
+        if (x != -1 & y != -1) {
             distances = sqrt((x - all_inds.x) ^ 2 + (y - all_inds.y) ^ 2);
+            where = " around [" + x + ", " + y + "]";
+        } else {
+            where = " (sampled randomly)";
+        }
 
         if (isInfinite(n)) {
             n = length(all_inds);
@@ -360,7 +364,7 @@ s10 late() /* Remember individuals for tree sequence recording */ {
             n_str = asString(n);
 
         log_output("remembering " + n_str + " individuals of " +
-                             pop + "(p" + get_pop(pop).id + ")");
+                             pop + "(p" + get_pop(pop).id + ")" + where);
 
         // give a warning in case more individuals are scheduled for sampling
         // than are present in the population

--- a/inst/extdata/script.slim
+++ b/inst/extdata/script.slim
@@ -345,6 +345,10 @@ s10 late() /* Remember individuals for tree sequence recording */ {
         // only individuals not yet sampled are eligible for remembering
         all_inds = all_inds[all_inds.tag != 1];
 
+        x = event.getValue("x"); y = event.getValue("y");
+        if (x != -1 & y != -1)
+            distances = sqrt((x - all_inds.x) ^ 2 + (y - all_inds.y) ^ 2);
+
         if (isInfinite(n)) {
             n = length(all_inds);
             n_str = "all (" + n + ")";
@@ -366,7 +370,11 @@ s10 late() /* Remember individuals for tree sequence recording */ {
             n = length(all_inds);
         }
 
-        inds = sample(all_inds, asInteger(n));
+        if (exists("distances"))
+            inds = all_inds[order(distances)][0 : (n - 1)];
+        else
+            inds = sample(all_inds, asInteger(n));
+
         inds.tag = 1; // tag sampled individuals as remembered
         sim.treeSeqRememberIndividuals(inds, permanent = T);
     }

--- a/inst/extdata/script.slim
+++ b/inst/extdata/script.slim
@@ -691,7 +691,8 @@ function (ifsl) convert_type(s$ column_name, s string_values) {
                 "tsplit_orig", "tsplit_gen", "tdispersal_orig", "tdispersal_gen",
                 "tremove_orig", "tremove_gen", "tstart_orig", "tstart_gen",
                 "tend_orig", "tend_gen", "tresize_orig", "tresize_gen");
-    float = c("rate", "competition_dist", "mate_dist", "dispersal_dist", "n");
+    float = c("rate", "competition_dist", "mate_dist", "dispersal_dist", "n",
+              "x", "y", "x_orig", "y_orig");
     logical = c("overlap");
 
     if (any(column_name == integer))

--- a/man/sampling.Rd
+++ b/man/sampling.Rd
@@ -2,9 +2,9 @@
 % Please edit documentation in R/interface.R
 \name{sampling}
 \alias{sampling}
-\title{Define sampling events at specified times for a given set of populations}
+\title{Define sampling events for a given set of populations}
 \usage{
-sampling(model, times, ..., strict = FALSE)
+sampling(model, times, ..., locations = NULL, strict = FALSE)
 }
 \arguments{
 \item{model}{Object of the class \code{slendr_model}}
@@ -16,14 +16,33 @@ schedule remembering of individuals in the tree-sequence}
 of individuals to sample), representing from which populations should how
 many individuals be remembered at times given by \code{times}}
 
+\item{locations}{List of vector pairs, defining two-dimensional coordinates
+of locations at which the closest number of individuals from given
+populations should be sampled. If \code{NULL} (the default), individuals
+will be sampled randomly throughout their spatial boundary.}
+
 \item{strict}{Should any occurence of a population not being present at a
-given time result in an error? Default is \code{FALSE}, meaning that invalid
-sampling times for any populations will be quietly ignored.}
+given time result in an error? Default is \code{FALSE}, meaning that
+invalid sampling times for any populations will be quietly ignored.}
+
+\item{remove}{Time at which the population should be removed}
 }
 \value{
-Data frame with three columns: time of sampling, population
-to sample from, how many individuals to sample
+Data frame with three columns: time of sampling, population to sample
+from, how many individuals to sample
 }
 \description{
-Define sampling events at specified times for a given set of populations
+Schedule sampling events at specified times and, optionally, a given set of
+locations on a landscape
+}
+\details{
+If both times and locations are given, the the sampling will be scheduled on
+each specified location in each given time-point. Note that for the
+time-being, in the interest of simplicity, no sanity checks are performed on
+the locations given except the restriction that the sampling points must fall
+within the bounding box around the simulated world map. Other than that,
+slendr will simply instruct its SLiM backend script to sample individuals as
+close to the sampling points given as possible, regardless of whethere those
+points lie within a population spatial boundary at that particular moment of
+time.
 }

--- a/tests/testthat/helper-functions.R
+++ b/tests/testthat/helper-functions.R
@@ -1,0 +1,9 @@
+# conda create --name retipy tskit pyslim msprime
+env_present <- function(env) {
+  tryCatch({
+    reticulate::use_condaenv(env, required = TRUE)
+    return(TRUE)
+  },
+  error = function(cond) FALSE
+  )
+}

--- a/tests/testthat/test-coordinate-conversions.R
+++ b/tests/testthat/test-coordinate-conversions.R
@@ -40,15 +40,7 @@ test_that("'x' and 'y' columns are present in each input data.frame", {
 # conversion returns correct type
 ######################################################################
 
-test_that("single point conversion returns a vector", {
-  coord <- c(0, 0)
-  expect_type(
-    reproject(coord[1], coord[2], from = "raster", to = "raster", model = model),
-    "double"
-  )
-})
-
-test_that("single point conversion returns a vector", {
+test_that("coordinate conversion returns a data frame", {
   expect_s3_class(reproject(x = c(1, 10), y = c(0, 5), from = "raster", to = "raster", model = model), "data.frame")
 })
 
@@ -70,28 +62,33 @@ test_that("coordinates are correctly added to a given data.frame", {
 ######################################################################
 
 test_that("raster coordinates project onto themselves", {
-  coord <- c(0, 0)
-  expect_equal(coord, reproject(coord[1], coord[2], from = "raster", to = "raster", model = model))
+  coord <- data.frame(x = 0, y = 0)
+  new_coord <- reproject(coords = coord, from = "raster", to = "raster", model = model, output_prefix = "")
+  expect_equal(coord, new_coord)
 })
 
 test_that("longitude-latitude coordinates project onto themselves", {
   coord <- c(0, 0)
-  expect_equal(coord, reproject(coord[1], coord[2], from = 4326, to = 4326))
+  new_coord <- reproject(coord[1], coord[2], from = 4326, to = 4326, output_prefix = "")
+  expect_equal(coord, as.vector(unlist(new_coord)))
 })
 
 test_that("projected coordinates project onto themselves", {
   coord <- c(0, 0)
-  expect_equal(coord, reproject(coord[1], coord[2], from = 3035, to = 3035))
+  new_coord <- reproject(coord[1], coord[2], from = 3035, to = 3035)
+  expect_equal(coord, as.vector(unlist(new_coord)))
 })
 
 test_that("geographic coordinates project onto projected coordinates", {
   coord <- c(0, 0)
-  new_coord <- reproject(coord[1], coord[2], from = 4326, to = 3035)
-  expect_equal(coord, reproject(new_coord[1], new_coord[2], from = 3035, to = 4326))
+  new_coord <- reproject(coord[1], coord[2], from = 4326, to = 3035, output_prefix = "")
+  orig_coord <- reproject(new_coord[1], new_coord[2], from = 3035, to = 4326, output_prefix = "")
+  expect_equal(coord, as.vector(unlist(orig_coord)))
 })
 
 test_that("projected coordinates project onto geographic coordinates", {
   coord <- c(1000000, 1000000)
   new_coord <- reproject(coord[1], coord[2], from = 3035, to = 4326)
-  expect_equal(coord, reproject(new_coord[1], new_coord[2], from = 4326, to = 3035))
+  orig_coord <- reproject(new_coord[1], new_coord[2], from = 4326, to = 3035)
+  expect_equal(coord, as.vector(unlist(orig_coord)))
 })

--- a/tests/testthat/test-sampling.R
+++ b/tests/testthat/test-sampling.R
@@ -66,7 +66,7 @@ test_that("only locations within world bounds are valid", {
   expect_silent(check_location_bounds(valid, map))
 })
 
-test_that("sampling takes place as close to the specified position as possible", {
+test_that("sampling is as close to the a single specified position as possible", {
   skip_if(!env_present("retipy"))
 
   n_samples <- 5
@@ -120,4 +120,91 @@ test_that("sampling takes place as close to the specified position as possible",
   expect_true(all.equal(individuals$x, locations$x, tolerance = 0.001))
   expect_true(all.equal(individuals$y, locations$y, tolerance = 0.001))
   expect_true(all.equal(individuals$distance, locations$distance, tolerance = 0.001))
+})
+
+test_that("sampling is as close to the multiple specified positions as possible", {
+  skip_if(!env_present("retipy"))
+
+  n_samples <- 5
+  times <- c(10, 100)
+  locations <- list(c(0, 0), c(100, 100))
+  sim_length <- 100
+
+  map <- world(xrange = c(0, 100), yrange = c(0, 100), landscape = "blank")
+  pop <- population("pop", 1, 100, map = map, center = c(50, 50), radius = 50)
+  model <- compile(pop, dir = tempdir(), generation_time = 1,
+                   competition_dist = 10, mate_dist = 10, dispersal_dist = 10,
+                   sim_length = sim_length, resolution = 1, overwrite = TRUE)
+
+  samples <- rbind(
+    sampling(model, times = times[1], locations = locations[1], list(pop, n_samples)),
+    sampling(model, times = times[2], locations = locations[2], list(pop, n_samples))
+  )
+
+  slim(model, sequence_length = 1, recombination_rate = 0, sampling = samples,
+       method = "batch", save_locations = TRUE, verbose = FALSE)
+
+  # load the locations of all individuals throughout the simulation, and filter
+  # down to `n_sample` of the ones closest to the sampling location [50, 50] in
+  # each time point (essentially replicating what we're doing on the SLiM
+  # backend during the simulation run)
+  all_locations <- file.path(model$path, "output_ind_locations.tsv.gz") %>%
+    readr::read_tsv(show_col_types = FALSE) %>%
+    dplyr::mutate(time = sim_length - gen + 1)
+
+  first_loc <- all_locations %>%
+    dplyr::filter(time == times[1]) %>%
+    dplyr::group_by(time) %>%
+    dplyr::mutate(distance = sqrt((locations[[1]][1] - x)^2 + (locations[[1]][2] - y)^2)) %>%
+    dplyr::arrange(time, distance) %>%
+    dplyr::mutate(i = 1:dplyr::n()) %>%
+    dplyr::filter(i %in% 1:n_samples) %>%
+    dplyr::ungroup() %>%
+    dplyr::select(ind, time, x, y, distance) %>%
+    dplyr::arrange(time, distance) %>%
+    as.data.frame()
+
+  second_loc <- all_locations %>%
+    dplyr::filter(time == times[2]) %>%
+    dplyr::group_by(time) %>%
+    dplyr::mutate(distance = sqrt((locations[[2]][1] - x)^2 + (locations[[2]][2] - y)^2)) %>%
+    dplyr::arrange(time, distance) %>%
+    dplyr::mutate(i = 1:dplyr::n()) %>%
+    dplyr::filter(i %in% 1:n_samples) %>%
+    dplyr::ungroup() %>%
+    dplyr::select(ind, time, x, y, distance) %>%
+    dplyr::arrange(time, distance) %>%
+    as.data.frame()
+
+  locs <- rbind(first_loc, second_loc)
+
+  # load locations of individuals remembered in the tree sequence
+  ts <- ts_load(model)
+  all_individuals <- ts_data(ts, remembered = TRUE) %>%
+    dplyr::select(-node_id) %>%
+    dplyr::distinct() %>%
+    dplyr::mutate(
+      x = sf::st_coordinates(.)[, "X"],
+      y = sf::st_coordinates(.)[, "Y"]
+    ) %>%
+    dplyr::as_tibble() %>%
+    dplyr::select(ind_id, time, x, y)
+
+  first_individuals <- all_individuals %>%
+    dplyr::filter(time == times[1]) %>%
+    dplyr::mutate(distance = sqrt((locations[[1]][1] - x)^2 + (locations[[1]][2] - y)^2)) %>%
+    dplyr::arrange(time, distance) %>%
+    as.data.frame()
+
+  second_individuals <- all_individuals %>%
+    dplyr::filter(time == times[2]) %>%
+    dplyr::mutate(distance = sqrt((locations[[2]][1] - x)^2 + (locations[[2]][2] - y)^2)) %>%
+    dplyr::arrange(time, distance) %>%
+    as.data.frame()
+
+  individuals <- rbind(first_individuals, second_individuals)
+
+  expect_true(all.equal(individuals$x, locs$x, tolerance = 0.001))
+  expect_true(all.equal(individuals$y, locs$y, tolerance = 0.001))
+  expect_true(all.equal(individuals$distance, locs$distance, tolerance = 0.001))
 })

--- a/tests/testthat/test-sampling.R
+++ b/tests/testthat/test-sampling.R
@@ -55,3 +55,13 @@ test_that("sampling in the same generation of the split is prevented (backward)"
   model <- compile(populations = p1, dir = tempdir(), generation_time = 25, overwrite = TRUE)
   expect_warning(sampling(model, time = 97, list(p1, 3)), "No valid sampling")
 })
+
+# spatial sampling --------------------------------------------------------
+
+test_that("only locations within world bounds are valid", {
+  map <- world(xrange = c(0, 100), yrange = c(0, 100), landscape = "blank")
+  valid <- list(c(100, 100), c(0, 0), c(30, 5))
+  invalid <- list(c(1000, 100), c(0, 0), c(30, 5))
+  expect_error(check_location_bounds(invalid, map), "locations fall outside")
+  expect_silent(check_location_bounds(valid, map))
+})

--- a/tests/testthat/test-ts.R
+++ b/tests/testthat/test-ts.R
@@ -1,13 +1,3 @@
-# conda create --name retipy tskit pyslim msprime
-env_present <- function(env) {
-  tryCatch({
-    reticulate::use_condaenv(env, required = TRUE)
-    return(TRUE)
-  },
-  error = function(cond) FALSE
-)
-}
-
 skip_if(!env_present("retipy"))
 
 map <- world(xrange = c(0, 3500), yrange = c(0, 700), landscape = "blank")

--- a/tests/testthat/test-ts.R
+++ b/tests/testthat/test-ts.R
@@ -51,7 +51,7 @@ test_that("tree sequence contains the specified number of sampled individuals", 
     dplyr::as_tibble() %>%
     dplyr::distinct(ind_id, time, pop) %>%
     dplyr::count(time, pop)
-  expect_true(all(counts == samples))
+  expect_true(all(counts == samples[, c("time", "pop", "n")]))
 })
 
 test_that("locations and times in the tree sequence match values saved by SLiM", {


### PR DESCRIPTION
Implements an optional argument `locations = ` to `sampling()`, which can be used to specify _where_ (not just when) should individuals be samples.

The argument has the format such as `locations = list(c(x1, y1), c(x2, y2), c(x3, y3), ...))`. Sampling in each time point will happen for the given number of individuals which are closes (using Euclidean distance) to the locations specified.