### PR TITLE
Windows port of the msprime functionality

### DIFF
--- a/R/compilation.R
+++ b/R/compilation.R
@@ -635,7 +635,7 @@ msprime <- function(model, sequence_length, recombination_rate, samples = NULL,
     cat("--------------------------------------------------\n\n")
   }
 
-  reticulate::py_run_string(sprintf("import os; os.system('%s')", msprime_command))
+  reticulate::py_run_string(sprintf("import os; os.system(r'%s')", msprime_command))
 
   # if (system(msprime_command, ignore.stdout = !verbose) != 0)
   #   stop("msprime simulation resulted in an error -- see the output above", call. = FALSE)

--- a/R/compilation.R
+++ b/R/compilation.R
@@ -607,16 +607,9 @@ msprime <- function(model, sequence_length, recombination_rate, samples = NULL,
   } else
     sampling <- ""
 
-  msprime_command <- sprintf("python3 \\
-    %s \\
-    %s \\
-    --model %s \\
-    --output %s \\
-    --sequence-length %d \\
-    --recombination-rate %s \\
-    %s \\
-    %s \\
-    %s",
+  msprime_command <- sprintf(
+    "%s %s %s --model %s --output %s --sequence-length %d --recombination-rate %s %s %s %s",
+    reticulate::py_exe(),
     script_path,
     ifelse(is.null(random_seed), "", paste("--seed", random_seed)),
     path.expand(model_dir),

--- a/inst/scripts/script.py
+++ b/inst/scripts/script.py
@@ -92,7 +92,7 @@ for pop in populations.itertuples():
     name = pop.pop
     if len(resizes) and name in set(resizes["pop"]):
         resize_events = resizes.query(f"pop == '{name}'")
-        initial_size = resize_events.tail(1).N[0]
+        initial_size = resize_events.tail(1).N.values[0]
     else:
         initial_size = pop.N
 


### PR DESCRIPTION
A student in the department (complete newbie to popgen and simulations) has a Windows laptop and wants to run some simple coalescent simulations. This should hopefully unlock the option to run Python-based msprime simulations in slendr.

Running SLiM in slendr requires working with the OS command-line and slendr currently does it using unix terminal under the hood. Porting this to Windows will be more work (it's been > 10 years since I touched `cmd.exe` on a Windows machine), but at least the Windows Python/msprime port should be relatively straightforward, so let's focus on that here.