### PR TITLE
Fix `ts_simplify` when `filter_nodes` and `filter_individuals` are `FALSE`

### DIFF
--- a/R/tree-sequences.R
+++ b/R/tree-sequences.R
@@ -2480,7 +2480,7 @@ get_ts_raw_individuals <- function(ts) {
   # (unlike the raw tree-sequence tables, IDs are explicitly stored as 0-based columns)
   ind_table <- dplyr::tibble(
     # ind_id = seq_len(ts$num_individuals) - 1
-    ind_id = reticulate::iterate(ts$individuals(), function(ind) ind$id, simplify = TRUE)
+    ind_id = as.numeric(reticulate::iterate(ts$individuals(), function(ind) ind$id, simplify = TRUE))
   )
 
   if (attr(ts, "type") == "SLiM") {


### PR DESCRIPTION
This fixes an issue caused by slendr assuming that in an msprime-made tree sequence, all individual nodes are always samples. Which is not true when re-numbering of nodes is prevented during simplification. This fix primarily involves `sampled = nodes[["flags"]] == tskit$NODE_IS_SAMPLE` as a means to assign a sampled-or-not status to a node (and, by extension, an individual).