### PR TITLE
Revert "Change the procedure for checking Python presence"

### DIFF
--- a/R/interface.R
+++ b/R/interface.R
@@ -1352,9 +1352,7 @@ init_env <- function(quiet = FALSE) {
          "on your system ('", PYTHON_ENV, "').\n\n",
          "To set up a dedicated Python environment you first need to run setup_env().", call. = FALSE)
   else {
-    # reticulate::use_condaenv(PYTHON_ENV, required = TRUE)
-    python_path <- slendr::get_python()
-    reticulate::use_python(python_path, required = TRUE)
+    reticulate::use_condaenv(PYTHON_ENV, required = TRUE)
 
     # this is an awful workaround around the reticulate/Python bug which prevents
     # import_from_path (see zzz.R) from working properly -- I'm getting nonsensical

--- a/R/utils.R
+++ b/R/utils.R
@@ -728,11 +728,10 @@ ask_install <- function(module) {
 }
 
 is_slendr_env_present <- function() {
-  # tryCatch({
-  #   PYTHON_ENV %in% reticulate::conda_list()$name
-  # }, error = function(cond) FALSE
-  # )
-  file.exists(get_python())
+  tryCatch({
+    PYTHON_ENV %in% reticulate::conda_list()$name
+  }, error = function(cond) FALSE
+  )
 }
 
 is_slim_present <- function() {


### PR DESCRIPTION
This effectively reverts commit 0aa82331681bbc83f41baadd26ba456009839d1f.

This change was originally introduced because of a strange race condition in conda when running parallelized slendr simulations for the [demografr](github.com/bodkan/demografr) package. A fix for this was to activate slendr's Python environment via Python path provided by by the reticulate package (a path to a `python` binary in the environment location... which effectively activates that environment). Previously, the environment was activated via dedicated conda function in reticulate, which caused that obscure race condition.

Sadly, on some systems (I suspect those which have their own conda set up, in addition to R/reticulate's own miniconda, such as mentioned [here](#179)) there's an obscure broken interaction somewhere along the axis of `reticulate <-> R <-> conda / OS`, which causes the following problem:

1. User successfully installs the slendr Python environment using R/reticulate's own miniconda.
2. That environment is, for some strange reason, NOT installed in reticulates r-miniconda path, but is installed into system-wide conda path.
3. As a result, when slendr later tries to activate its environment using reticulates own r-miniconda... that environment is being looked for in the incorrect location.

This could be a new misfeature either in reticulate or in conda, but that doesn't matter. Either way, it's outside of slendr's sphere of influence.

Reverting this change probably disqualifies the usage of the demografr ABC package on Windows. But, honestly, practically speaking, nobody is going to run massively parallelized ABC simulations on Windows anyway. 

Practicality beats purity yet again. :(