### PR TITLE
Agree to whatever terms conda wants us to agree to (closes #183)

### DIFF
--- a/R/interface.R
+++ b/R/interface.R
@@ -1457,6 +1457,7 @@ setup_env <- function(quiet = FALSE, agree = FALSE, pip = FALSE) {
     message("A required slendr Python environment is already present. You can activate\n",
             "it by calling init_env().")
   } else {
+    Sys.setenv(CONDA_PLUGINS_AUTO_ACCEPT_TOS = "yes")
     if (agree)
       answer <- 2
     else


### PR DESCRIPTION
OK, [this](https://github.com/bodkan/slendr/issues/183) new silly conda issue is appearing to bite enough students in classrooms to warrant a (semi-)permanent emergency fix. This involves setting a new environment variable in the R session (explained in the linked issue), which actually won't break anything else even in setups and operating systems on which conda, for some unknown reasonm doesn't require the user to agreem to terms of service.