### PR TITLE
Add Docker setup for slendr development and testing

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -25,4 +25,6 @@
 .codecov.yml
 ubuntu_deps.txt
 ^vignettes/vignette-09-paper\.Rmd$
-TAGS
+Dockerfile
+docker
+tags

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,106 @@
+FROM rocker/rstudio:4.5.3
+
+LABEL maintainer="Martin Petr <mp@bodkan.net>"
+
+############################################################
+# setup the base system
+############################################################
+
+ENV DEBIAN_FRONTEND="noninteractive"
+
+RUN apt-get update -y \
+    && apt-get upgrade -y \
+    && apt-get install -yqq --no-install-recommends \
+        build-essential \
+        cmake \
+        curl \
+        gdal-bin \
+        git \
+        htop \
+        iputils-ping \
+        less \
+        libblas-dev \
+        libbz2-dev \
+        libcurl4-openssl-dev \
+        libffi-dev \
+        libfftw3-dev \
+        libfontconfig1-dev \
+        libfribidi-dev \
+        libgdal-dev \
+        libgit2-dev \
+        libglpk-dev \
+        libglu1 \
+        libgsl-dev \
+        liblapack-dev \
+        libharfbuzz-dev \
+        libmagick++-dev \
+        libnlopt-cxx-dev \
+        libpopt-dev \
+        libreadline-dev \
+        librsvg2-dev \
+        libsnappy1v5 \
+        libssl-dev \
+        libsqlite3-dev \
+        libtiff5-dev \
+        libudunits2-dev \
+        libunwind-dev \
+        libwebp-dev \
+        libxml2-dev \
+        libxt6 \
+        libzmq5 \
+        libzstd-dev \
+        man-db \
+        parallel \
+        rename \
+        tmux \
+        tree \
+        unminimize \
+        vim \
+        wget \
+        zlib1g-dev
+
+# fix 'Errors were encountered while processing: fontconfig' during unminimize
+RUN fc-cache -f; yes | unminimize
+
+# the container is intended as a dedicated environment to be run in a rootless setting
+ENV HOME="/root"
+
+############################################################
+# compile and install third-party software dependencies
+############################################################
+
+# compile SLiM
+RUN cd /tmp; wget https://github.com/MesserLab/SLiM/archive/refs/tags/v5.1.tar.gz -O slim.tar.gz; \
+    tar xf slim.tar.gz; cd SLiM-*; mkdir build; cd build; cmake ..; make slim eidos
+
+# install all compiled software into $PATH
+RUN cd /tmp; cp SLiM-*/build/slim SLiM-*/build/eidos /usr/bin
+
+############################################################
+# install R packages required by the project
+############################################################
+
+# location for the whole project (scripts, notebooks, and data) inside the container
+ENV PROJECT=/project
+WORKDIR $PROJECT
+
+# install dependencies and setup the slendr Python environment
+RUN R -e 'install.packages(c("pak", "devtools"))'
+COPY ./ /tmp/slendr
+RUN R -e 'pak::local_install("/tmp/slendr", dependencies = TRUE)'
+RUN R -e 'slendr::setup_env(agree = TRUE, pip = TRUE); remove.packages("slendr")'
+
+# make sure all software is available in R
+RUN echo "PATH=$PATH" >> ${HOME}/.Renviron
+
+############################################################
+# final configuration steps
+############################################################
+
+# make sure the project is ready when RStudio Server session starts
+# https://docs.posit.co/ide/server-pro/admin/rstudio_pro_sessions/session_startup_scripts.html
+# https://community.rstudio.com/t/how-to-set-the-default-startup-project-in-rocker-tidyverse/63092/2
+RUN echo "\nsetHook('rstudio.sessionInit', \(new) if (new && is.null(rstudioapi::getActiveProject())) rstudioapi::openProject('${PROJECT}'))" >> ${HOME}/.Rprofile
+
+# remove compilation sources and other redundant files
+RUN rm -r /tmp/* /home/rstudio

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ clean:
 
 $(pkg): README.md
 	R -e 'devtools::document()'
-	unset R_HAS_GGTREE; mkdir -p build; cd build; R CMD build --log ../../slendr
+	unset R_HAS_GGTREE; mkdir -p build; cd build; R CMD build --log ../../$(notdir $(CURDIR))
 
 README.md: README.Rmd $(logo)
 	R -e 'devtools::install(upgrade = FALSE)'

--- a/docker
+++ b/docker
@@ -1,0 +1,100 @@
+##################################################################
+# Docker shortcuts for make
+#
+# Usage examples:
+#
+#   make -f docker build    # builds a slendr Docker image
+#   make -f docker bash     # creates an interactive shell
+#   make -f docker R        # creates an interactive R session
+#   make -f docker rstudio  # creates an RStudio Server instance
+#
+
+# check the OS type to assign appropriate Docker image tag
+ifeq ($(shell uname -s), Darwin)
+    PLATFORM ?= arm64
+else
+    PLATFORM ?= amd64
+endif
+
+IMAGE := bodkan/$(shell basename $(shell pwd)):$(PLATFORM)
+CONTAINER := $(shell basename $(shell pwd))
+
+# if present, extract GitHub access token
+TOKEN := $(shell if [[ -f ~/.GITHUB_PAT ]]; then more ~/.GITHUB_PAT; else echo ""; fi)
+
+.PHONY: rstudio bash r build push pull local-webapp remote-webapp
+
+bash:
+	docker run --rm -ti -v $(shell pwd):/project -w /project --name $(CONTAINER) $(IMAGE) bash
+
+r:
+	docker run --rm -ti -v $(shell pwd):/project -w /project --name $(CONTAINER) $(IMAGE) R
+
+attach:
+	container_id=`docker ps | awk -v name="$$(basename "$$PWD")" '$$2 ~ name {print $$1}'`; \
+	docker exec -it $$container_id /bin/bash
+
+rstudio:
+ifndef PORT
+	$(error PORT variable must be set explicitly)
+endif
+	docker run --rm -ti -p $(PORT):8787 -e RUNROOTLESS=true -e DISABLE_AUTH=true -v $(shell pwd):/project --name $(CONTAINER) $(IMAGE)
+
+build:
+	docker build --build-arg GITHUB_PAT=$(TOKEN) -t $(IMAGE) .
+
+build-clean:
+	@echo $(IMAGE)
+	docker build --no-cache --build-arg GITHUB_PAT=$(TOKEN) -t $(IMAGE) .
+
+push:
+	docker push $(IMAGE)
+
+pull:
+	docker pull $(IMAGE)
+
+stop:
+	docker stop $(CONTAINER) || true
+
+local-webapp:
+ifndef PORT
+	$(error PORT variable must be set explicitly)
+endif
+	chromium --app=http://localhost:$(PORT) &
+
+remote-webapp:
+ifndef SERVER
+	$(error SERVER variable must be set to start a web app)
+endif
+ifndef PORT
+	$(error PORT variable must be set explicitly)
+endif
+	@if [[ "$(SERVER)" != "localhost" ]]; then \
+	    PID=$$(lsof -ti:$(PORT)); \
+	    if [[ -n "$$PID" ]]; then \
+		kill -9 $$PID; \
+	    fi; \
+	    autossh -M 0 -f -N -L localhost:$(PORT):localhost:$(PORT) $(SERVER) || { \
+		echo "SSH connection failed. Exiting."; \
+		exit 1; \
+	    }; \
+	fi; \
+	chromium --app=http://localhost:$(PORT) &
+
+port-forward:
+ifndef SERVER
+	$(error SERVER variable must be set to start a web app)
+endif
+ifndef PORT
+	$(error PORT variable must be set explicitly)
+endif
+	@if [[ "$(SERVER)" != "localhost" ]]; then \
+	    PID=$$(lsof -ti:$(PORT)); \
+	    if [[ -n "$$PID" ]]; then \
+		kill -9 $$PID; \
+	    fi; \
+	    autossh -M 0 -f -N -L localhost:$(PORT):localhost:$(PORT) $(SERVER) || { \
+		echo "SSH connection failed. Exiting."; \
+		exit 1; \
+	    }; \
+	fi


### PR DESCRIPTION
The [recent disaster](https://github.com/bodkan/slendr/issues/193) with broken Python / reticulate / conda / GHA infrastructure finally prompted me to create a dedicated Docker container infrastructure for testing and development of slendr. I've been thinking about moving away from GHA (or maybe even GitHub itself) in the long-term and regardless of whether or not this ends up happening, having an independent self-contained infrastructure for testing slendr on Linux (which is where vast majority of high-performance simulations happens anyway) will be very useful. Just like it has been useful for the linked issue.

Furthermore, given the ever-changing landscape of a huge number of software dependencies and the constant danger of breakage due to minor (and sometimes, major) incompatibilities, I've been relying on containers for my research work for years now as a means to package entire projects in [a single artifact reproducible across all platforms](https://i.programmerhumor.io/2025/03/3d4d7cf0345843afb3e43052d37dd0ed94ac70f0c6f959d53c7df7d88c7c808b.jpeg). I've had a "using Docker -- stay tuned" in slendr docs since the very beginning and this might finally give me the infrastructure to develop the description of this approach further.

---

Examples of how I use this (utilizing the venerable, ever-present `make`):

- `make -f docker build` -- build a Docker image with all slendr dependencies
- `make -f docker bash` -- start a container with a bash shell in the current working directory (typically the slendr repo)
- `make -f docker R` -- start a container with an interactive R session console
- `make -f rstudio PORT=<number>` -- start an RStudio Server instance on the given port (typically on a remote server)
- `make -f remote-webapp SERVER=<name> PORT=<number>` -- open a "kiosk-mode" Chromium window and connect to the remote RStudio Server instance

---

For instance:

1. `make -f docker bash` starts an interactive shell
2. `make clean && make build && make check` in that shell executes the CRAN R CMD build / check workflow

Or:

1. `make -f docker R` starts an interactive R console
2. `devtools::load_all()` in the R console loads the development version of slendr for a normal R package development workflow (good enough for quick and simple testing)