### PR TITLE
Add uv as a fallback for systems with a broken conda / Python / reticulate interaction

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -161,9 +161,9 @@ jobs:
               "\n",
               "RSTUDIO_PANDOC=", normalizePath(dirname(pandoc::pandoc_bin()), winslash = "/"),
               "\n",
-              "GTIFF_SRS_SOURCE=EPSG # silence GDAL warning"
+              "GTIFF_SRS_SOURCE=EPSG # silence GDAL warning",
               "\n",
-              "SLENDR_UV=TRUE
+              "SLENDR_UV=TRUE"
             ),
             con = paste0(normalizePath(path.expand("~"), winslash = "/"), "/.Renviron"))
         shell: Rscript {0}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -117,11 +117,12 @@ jobs:
           cmake .
           make slim
 
-      - name: Populate PATH with compiled binaries on Unix
+      - name: Set necessary variables in ~/.Renviron on Unix
         if: runner.os != 'Windows'
         run: |
           export PATH="$HOME/deps/SLiM:$HOME/deps/AdmixTools-7.0.2/bin:$PATH"
           echo "PATH=$PATH" >> ~/.Renviron
+          echo "SLENDR_UV=TRUE" >> ~/.Renviron
 
       - name: Install SLiM on Windows
         if: runner.os == 'Windows'
@@ -151,7 +152,7 @@ jobs:
       #  run: dir ${{ runner.temp }}\msys64\usr\bin
       #  shell: cmd
 
-      - name: Populate PATH with compiled binaries on Windows
+      - name: Set necessary variables in ~/.Renviron on Windows
         if: runner.os == 'Windows'
         run: |
           writeLines(
@@ -161,6 +162,8 @@ jobs:
               "RSTUDIO_PANDOC=", normalizePath(dirname(pandoc::pandoc_bin()), winslash = "/"),
               "\n",
               "GTIFF_SRS_SOURCE=EPSG # silence GDAL warning"
+              "\n",
+              "SLENDR_UV=TRUE
             ),
             con = paste0(normalizePath(path.expand("~"), winslash = "/"), "/.Renviron"))
         shell: Rscript {0}
@@ -176,12 +179,6 @@ jobs:
       #     cat(Sys.getenv("RSTUDIO_PANDOC"), "\n")
       #   shell: Rscript {0}
 
-      - name: Set R_LIBS path on unix
-        if: runner.os == 'Windows'
-        run: |
-          mkdir ~/R_LIBS
-          echo "GTIFF_SRS_SOURCE='EPSG'" >> ~/.Renviron
-
       - uses: r-lib/actions/setup-pandoc@v2
 
       - uses: r-lib/actions/setup-r@v2
@@ -194,18 +191,5 @@ jobs:
         with:
           extra-packages: any::rcmdcheck
           needs: check
-
-      - name: Setup dedicated Python environment for slendr
-        run: |
-          install.packages("reticulate", repos = "http://cran.rstudio.com")
-          reticulate::install_miniconda()
-          deps <- c("msprime==1.4.1", "tskit==1.0.2", "pyslim==1.1.1")
-          PYTHON_ENV <- paste0("Python-3.12_", paste(gsub("==", "-", c(deps, "tspop==0.0.2")), collapse = "_"))
-          reticulate::conda_create(envname = PYTHON_ENV, python_version = '3.12')
-          reticulate::use_condaenv(PYTHON_ENV, required = TRUE)
-          reticulate::conda_install(envname = PYTHON_ENV, packages = c("msprime==1.4.1", "tskit==1.0.2"), pip = TRUE)
-          reticulate::conda_install(envname = PYTHON_ENV, packages = c("pyslim==1.1.1", "pandas==2.3.3", "pyarrow"), pip = TRUE)
-          reticulate::conda_install(envname = PYTHON_ENV, packages = c("tspop==0.0.2"), pip = TRUE)
-        shell: Rscript {0}
 
       - uses: r-lib/actions/check-r-package@v2

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -170,6 +170,20 @@ jobs:
             con = paste0(normalizePath(path.expand("~"), winslash = "/"), "/.Renviron"))
         shell: Rscript {0}
 
+      - name: Install reticulate
+        if: runner.os == 'Windows'
+        run: |
+          install.packages("reticulate", repos = "http://cran.rstudio.com")
+        shell: Rscript {0}
+
+      - name: Setup uv
+        if: runner.os == 'Windows'
+        run: |
+          library(reticulate)
+          py_require("tskit")
+          print(py_module_available("tskit"))
+        shell: Rscript {0}
+
         # The Windows GDAL GitHub Actions warning solved by setting 'GTIFF_SRS_SOURCE' above
         # is actually not the first time this happened, interesting:
         # https://github.com/bodkan/slendr/blob/3e02fa2ad7fb085ccbcc23df518bca6b72e782b1/R/compilation.R#L730

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -161,34 +161,28 @@ jobs:
               "\n",
               "RSTUDIO_PANDOC=", normalizePath(dirname(pandoc::pandoc_bin()), winslash = "/"),
               "\n",
-              "GTIFF_SRS_SOURCE=EPSG # silence GDAL warning",
-              "\n",
-              "RETICULATE_PYTHON='managed'",
-              "\n",
-              "SLENDR_UV=TRUE"
+              "GTIFF_SRS_SOURCE=EPSG # silence GDAL warning"
             ),
             con = paste0(normalizePath(path.expand("~"), winslash = "/"), "/.Renviron"))
         shell: Rscript {0}
 
-      - name: Setup PowerShell
+      - name: Setup dedicated Python environment for slendr
         if: runner.os == 'Windows'
         run: |
-          winget search Microsoft.PowerShell
-          winget install --id Microsoft.PowerShell --source winget
-        shell: cmd
-
-      - name: Install reticulate
-        if: runner.os == 'Windows'
-        run: |
-          install.packages("reticulate", repos = "http://cran.rstudio.com")
-        shell: Rscript {0}
-
-      - name: Setup uv
-        if: runner.os == 'Windows'
-        run: |
+          install.packages(c("magrittr", "reticulate"), repos = "http://cran.rstudio.com")
           library(reticulate)
-          py_require("tskit")
-          print(py_module_available("tskit"))
+          library(magrittr)
+          install_miniconda()
+          PYTHON_VERSION <- "3.12"
+          PYTHON_DEPS <- c("msprime==1.4.1", "tskit==1.0.2", "pyslim==1.1.1", "tspop==0.0.2")
+          PYTHON_ENV <-
+            PYTHON_DEPS %>%
+            gsub("==", "-", .) %>%
+            paste(collapse = "_") %>%
+            paste0("Python-", PYTHON_VERSION, "_", .)
+          conda_create(envname = PYTHON_ENV, python_version = PYTHON_VERSION)
+          use_condaenv(PYTHON_ENV, required = TRUE)
+          conda_install(envname = PYTHON_ENV, packages = PYTHON_DEPS, pip = TRUE)
         shell: Rscript {0}
 
         # The Windows GDAL GitHub Actions warning solved by setting 'GTIFF_SRS_SOURCE' above

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -163,6 +163,8 @@ jobs:
               "\n",
               "GTIFF_SRS_SOURCE=EPSG # silence GDAL warning",
               "\n",
+              "RETICULATE_PYTHON='managed'",
+              "\n",
               "SLENDR_UV=TRUE"
             ),
             con = paste0(normalizePath(path.expand("~"), winslash = "/"), "/.Renviron"))

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -170,6 +170,13 @@ jobs:
             con = paste0(normalizePath(path.expand("~"), winslash = "/"), "/.Renviron"))
         shell: Rscript {0}
 
+      - name: Setup PowerShell
+        if: runner.os == 'Windows'
+        run: |
+          winget search Microsoft.PowerShell
+          winget install --id Microsoft.PowerShell --source winget
+        shell: cmd
+
       - name: Install reticulate
         if: runner.os == 'Windows'
         run: |

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -68,32 +68,15 @@ jobs:
           cmake .
           make slim
 
-      - name: Populate PATH with compiled binaries
+      - name: Set necessary variables in ~/.Renviron
         run: |
           export PATH="$HOME/deps/SLiM:$HOME/deps/AdmixTools-7.0.2/bin:$PATH"
           echo "PATH=$PATH" >> ~/.Renviron
-
-      - name: Set R_LIBS path on unix
-        run: |
-          mkdir ~/R_LIBS
-          echo "R_LIBS_USER=~/R_LIBS" >> ~/.Renviron
+          echo "SLENDR_UV=TRUE" >> ~/.Renviron
 
       - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
-
-      - name: Setup dedicated Python environment for slendr
-        run: |
-          install.packages("reticulate", repos = "http://cran.rstudio.com")
-          reticulate::install_miniconda()
-          deps <- c("msprime==1.4.1", "tskit==1.0.2", "pyslim==1.1.1")
-          PYTHON_ENV <- paste0("Python-3.12_", paste(gsub("==", "-", c(deps, "tspop==0.0.2")), collapse = "_"))
-          reticulate::conda_create(envname = PYTHON_ENV, python_version = '3.12')
-          reticulate::use_condaenv(PYTHON_ENV, required = TRUE)
-          reticulate::conda_install(envname = PYTHON_ENV, packages = c("msprime==1.4.1", "tskit==1.0.2"), pip = TRUE)
-          reticulate::conda_install(envname = PYTHON_ENV, packages = c("pyslim==1.1.1", "pandas==2.3.3", "pyarrow"), pip = TRUE)
-          reticulate::conda_install(envname = PYTHON_ENV, packages = c("tspop==0.0.2"), pip = TRUE)
-        shell: Rscript {0}
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -14,25 +14,16 @@ concurrency:
 
 jobs:
   test-coverage:
-    #runs-on: ubuntu-latest
-    runs-on: macOS-latest
+    runs-on: ubuntu-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install rgdal dependencies (macOS)
-        if: runner.os == 'macOS'
-        run: brew install gdal
-
       - name: Install R dependencies (Linux)
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install libpng-dev
-
-      - name: Install ADMIXTOOLS dependencies (macOS)
-        if: runner.os == 'macOS'
-        run: brew install openblas gsl lapack bedtools
 
       - name: Install ADMIXTOOLS dependencies (Linux)
         if: runner.os == 'Linux'

--- a/Dockerfile
+++ b/Dockerfile
@@ -93,8 +93,8 @@ RUN cd /tmp/slendr; \
     if [ "$VERSION" != "dev" ]; then git checkout $VERSION; fi; \
     R -e 'pak::local_install(".", dependencies = TRUE)'
 
-# make sure all software is available in R
-RUN echo "PATH=$PATH" >> ${HOME}/.Renviron
+# set the necessary R environment variables for the container
+RUN echo -e "PATH=$PATH\nSLENDR_UV=TRUE" >> ${HOME}/.Renviron
 
 ############################################################
 # final configuration steps

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,6 +71,9 @@ ENV HOME="/root"
 # compile and install third-party software dependencies
 ############################################################
 
+# compile fzf
+RUN git clone --depth 1 https://github.com/junegunn/fzf.git ${HOME}/.fzf; ${HOME}/.fzf/install
+
 # compile SLiM
 RUN cd /tmp; wget https://github.com/MesserLab/SLiM/archive/refs/tags/v5.1.tar.gz -O slim.tar.gz; \
     tar xf slim.tar.gz; cd SLiM-*; mkdir build; cd build; cmake ..; make slim eidos
@@ -99,6 +102,10 @@ RUN printf "PATH=$PATH\nSLENDR_UV=TRUE\n" > ${HOME}/.Renviron
 ############################################################
 # final configuration steps
 ############################################################
+
+# clone shell configuration files into the container
+RUN cd ${HOME}; git clone https://github.com/bodkan/dotfiles .dotfiles/; rm -f .bashrc .profile; \
+    cd .dotfiles; ./install.sh
 
 # make sure the project is ready when RStudio Server session starts
 # https://docs.posit.co/ide/server-pro/admin/rstudio_pro_sessions/session_startup_scripts.html

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,8 +60,8 @@ RUN apt-get update -y \
         unminimize \
         vim \
         wget \
-        zlib1g-dev; \
-        tlmgr install inconsolata
+        zlib1g-dev
+RUN tlmgr install inconsolata
 
 # fix 'Errors were encountered while processing: fontconfig' during unminimize
 RUN fc-cache -f; yes | unminimize

--- a/Dockerfile
+++ b/Dockerfile
@@ -90,7 +90,7 @@ ENV PROJECT=/project
 WORKDIR $PROJECT
 
 # install dependencies and setup the slendr Python environment
-RUN R -e 'install.packages(c("pak", "devtools", "tinytex")); tinytex::install_tinytex()'
+RUN R -e 'install.packages(c("pak", "devtools"))'
 COPY ./ /tmp/slendr
 RUN cd /tmp/slendr; \
     if [ "$VERSION" != "dev" ]; then git checkout $VERSION; fi; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -91,8 +91,7 @@ RUN R -e 'install.packages(c("pak", "devtools"))'
 COPY ./ /tmp/slendr
 RUN cd /tmp/slendr; \
     if [ "$VERSION" != "dev" ]; then git checkout $VERSION; fi; \
-    R -e 'pak::local_install(".", dependencies = TRUE)'; \
-    R -e 'slendr::setup_env(agree = TRUE, pip = TRUE)'
+    R -e 'pak::local_install(".", dependencies = TRUE)'
 
 # make sure all software is available in R
 RUN echo "PATH=$PATH" >> ${HOME}/.Renviron

--- a/Dockerfile
+++ b/Dockerfile
@@ -89,8 +89,10 @@ WORKDIR $PROJECT
 # install dependencies and setup the slendr Python environment
 RUN R -e 'install.packages(c("pak", "devtools"))'
 COPY ./ /tmp/slendr
-RUN if [ "$VERSION" != "dev" ]; then git checkout $VERSION; fi; \
-    R -e 'pak::local_install("/tmp/slendr", dependencies = TRUE)'
+RUN cd /tmp/slendr; \
+    if [ "$VERSION" != "dev" ]; then git checkout $VERSION; fi; \
+    R -e 'pak::local_install(".", dependencies = TRUE)'; \
+    R -e 'slendr::setup_env(agree = TRUE, pip = TRUE)'
 
 # make sure all software is available in R
 RUN echo "PATH=$PATH" >> ${HOME}/.Renviron

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,8 @@ RUN apt-get update -y \
         unminimize \
         vim \
         wget \
-        zlib1g-dev
+        zlib1g-dev; \
+        tlmgr install inconsolata
 
 # fix 'Errors were encountered while processing: fontconfig' during unminimize
 RUN fc-cache -f; yes | unminimize

--- a/Dockerfile
+++ b/Dockerfile
@@ -94,7 +94,7 @@ RUN cd /tmp/slendr; \
     R -e 'pak::local_install(".", dependencies = TRUE)'
 
 # set the necessary R environment variables for the container
-RUN echo -e "PATH=$PATH\nSLENDR_UV=TRUE" >> ${HOME}/.Renviron
+RUN printf "PATH=$PATH\nSLENDR_UV=TRUE\n" > ${HOME}/.Renviron
 
 ############################################################
 # final configuration steps

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,7 @@ RUN apt-get update -y \
         man-db \
         parallel \
         rename \
+        texlive \
         tmux \
         tree \
         unminimize \

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,14 +54,12 @@ RUN apt-get update -y \
         man-db \
         parallel \
         rename \
-        texlive \
         tmux \
         tree \
         unminimize \
         vim \
         wget \
         zlib1g-dev
-RUN tlmgr install inconsolata
 
 # fix 'Errors were encountered while processing: fontconfig' during unminimize
 RUN fc-cache -f; yes | unminimize
@@ -92,7 +90,7 @@ ENV PROJECT=/project
 WORKDIR $PROJECT
 
 # install dependencies and setup the slendr Python environment
-RUN R -e 'install.packages(c("pak", "devtools"))'
+RUN R -e 'install.packages(c("pak", "devtools", "tinytex")); tinytex::install_tinytex()'
 COPY ./ /tmp/slendr
 RUN cd /tmp/slendr; \
     if [ "$VERSION" != "dev" ]; then git checkout $VERSION; fi; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -96,9 +96,6 @@ RUN cd /tmp/slendr; \
     if [ "$VERSION" != "dev" ]; then git checkout $VERSION; fi; \
     R -e 'pak::local_install(".", dependencies = TRUE)'
 
-# set the necessary R environment variables for the container
-RUN printf "PATH=$PATH\nSLENDR_UV=TRUE\n" > ${HOME}/.Renviron
-
 ############################################################
 # final configuration steps
 ############################################################
@@ -106,6 +103,9 @@ RUN printf "PATH=$PATH\nSLENDR_UV=TRUE\n" > ${HOME}/.Renviron
 # clone shell configuration files into the container
 RUN cd ${HOME}; git clone https://github.com/bodkan/dotfiles .dotfiles/; rm -f .bashrc .profile; \
     cd .dotfiles; ./install.sh
+
+# set the necessary R environment variables for the container
+RUN printf "PATH=$PATH\nSLENDR_UV=TRUE\n" > ${HOME}/.Renviron
 
 # make sure the project is ready when RStudio Server session starts
 # https://docs.posit.co/ide/server-pro/admin/rstudio_pro_sessions/session_startup_scripts.html

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ test:
 build: $(pkg)
 
 check: $(pkg)
-	unset R_HAS_GGTREE; cd build; R CMD check --as-cran $(notdir $<)
+	unset R_HAS_GGTREE; cd build; R CMD check --as-cran $(notdir $<) --no-manual
 
 winrel: README.md
 	unset R_HAS_GGTREE; R -e 'devtools::check_win_release()'

--- a/R/interface.R
+++ b/R/interface.R
@@ -1416,7 +1416,7 @@ schedule_sampling <- function(model, times, ..., locations = NULL, strict = FALS
 #'
 #' @export
 init_env <- function(uv = FALSE, quiet = FALSE) {
-  if (uv || Sys.getenv("SLENDR_UV" == TRUE)) {
+  if (uv || Sys.getenv("SLENDR_UV") == "TRUE") {
     reticulate::py_require(PYTHON_DEPS, PYTHON_VERSION)
   } else if (!check_dependencies(python = TRUE)) {
     stop("Could not activate slendr's Python environment because it is\n",

--- a/R/interface.R
+++ b/R/interface.R
@@ -1454,7 +1454,7 @@ init_env <- function(uv = FALSE, quiet = FALSE) {
     options(warning.length = 7000L)
     on.exit(options(warning.length = default_val))
     stop("A Python environment for slendr has been created but the following",
-         "modules appear to be missing:", which_missing,
+         " modules appear to be missing: ", which_missing,
          "\n\nPython environment summary:\n",
          paste(capture.output(reticulate::py_config()), collapse = "\n"),
          "\n\nInstalled Python modules:\n",

--- a/R/interface.R
+++ b/R/interface.R
@@ -1407,64 +1407,67 @@ schedule_sampling <- function(model, times, ..., locations = NULL, strict = FALS
 #' This function attempts to activate a dedicated slendr Miniconda Python
 #' environment previously set up via \code{setup_env}.
 #'
+#' @param uv Should an ephemeral Python environment be created via uv (instead
+#'   of activating a permanent virtual environment created via \code{setup_env})?
 #' @param quiet Should informative messages be printed to the console? Default
 #'   is \code{FALSE}.
 #'
 #' @return No return value, called for side effects
 #'
 #' @export
-init_env <- function(quiet = FALSE) {
-  if (!check_dependencies(python = TRUE))
-    stop("Could not activate slendr's Python environment because it is not\npresent ",
-         "on your system ('", PYTHON_ENV, "').\n\n",
-         "To set up a dedicated Python environment you first need to run setup_env().", call. = FALSE)
-  else {
+init_env <- function(uv = FALSE, quiet = FALSE) {
+  if (uv) {
+    reticulate::py_require(PYTHON_DEPS, PYTHON_VERSION)
+  } else if (!check_dependencies(python = TRUE)) {
+    stop("Could not activate slendr's Python environment because it is\n",
+         "not present on your system:\n\n", PYTHON_ENV, "\n\n",
+         "To set up a Python environment you first need to run `setup_env()` or\n",
+         "call `init_env(uv = TRUE)` to create an ephemeral Python environment.",
+         call. = FALSE)
+  } else {
     reticulate::use_condaenv(PYTHON_ENV, required = TRUE)
+  }
 
-    # this is an awful workaround around the reticulate/Python bug which prevents
-    # import_from_path (see zzz.R) from working properly -- I'm getting nonsensical
-    #   Error in py_call_impl(callable, dots$args, dots$keywords) :
-    #     TypeError: integer argument expected, got float
-    # in places with no integer/float conversion in sight
-    #
-    # at least it prevents having to do things like:
-    # reticulate::py_run_string("def get_pedigree_ids(ts): return [ind.metadata['pedigree_id']
-    #                                                              for ind in ts.individuals()]")
-    # (moved from ts_read() here because this is a better place for loading our Python functions)
-    reticulate::source_python(file = system.file("pylib/pylib.py", package = "slendr"))
+  # this is an awful workaround around the reticulate/Python bug which prevents
+  # import_from_path (see zzz.R) from working properly -- I'm getting nonsensical
+  #   Error in py_call_impl(callable, dots$args, dots$keywords) :
+  #     TypeError: integer argument expected, got float
+  # in places with no integer/float conversion in sight
+  #
+  # at least it prevents having to do things like:
+  # reticulate::py_run_string("def get_pedigree_ids(ts): return [ind.metadata['pedigree_id']
+  #                                                              for ind in ts.individuals()]")
+  # (moved from ts_read() here because this is a better place for loading our Python functions)
+  reticulate::source_python(file = system.file("pylib/pylib.py", package = "slendr"))
 
-    missing <- c(
-      "msprime" = !reticulate::py_module_available("msprime"),
-      "tskit" = !reticulate::py_module_available("tskit"),
-      "pyslim" = !reticulate::py_module_available("pyslim"),
-      "tspop" = !reticulate::py_module_available("tspop")
-    )
+  missing <- c(
+    "msprime" = !reticulate::py_module_available("msprime"),
+    "tskit" = !reticulate::py_module_available("tskit"),
+    "pyslim" = !reticulate::py_module_available("pyslim"),
+    "tspop" = !reticulate::py_module_available("tspop")
+  )
 
-    if (any(missing)) {
-      which_missing <- paste(names(missing)[missing], collapse = ", ")
-      packages <- reticulate::py_list_packages()[c("package", "version")]
-      default_val <- getOption("warning.length")
-      options(warning.length = 7000L)
-      on.exit(options(warning.length = default_val))
-      stop("Python environment ", PYTHON_ENV, " has been found but it",
-           " does not appear to have ", which_missing,
-           " installed. Perhaps the environment got corrupted somehow?",
-           " Running `clear_env()` and `setup_env()` to reset the slendr's Python",
-           " environment is recommended.",
-           "\n\nPython environment summary:\n",
-           paste(capture.output(reticulate::py_config()), collapse = "\n"),
-           "\n\nInstalled Python modules:\n",
-           paste(utils::capture.output(print(packages)), collapse = "\n"),
-           call. = FALSE)
-    } else {
-      # pylib <<- reticulate::import_from_path(
-      #   "pylib",
-      #   path = system.file("python", package = "slendr"),
-      #   delay_load = TRUE
-      # )
-      if (!quiet)
-        message("The interface to all required Python modules has been activated.")
-    }
+  if (any(missing)) {
+    which_missing <- paste(names(missing)[missing], collapse = ", ")
+    packages <- reticulate::py_list_packages()[c("package", "version")]
+    default_val <- getOption("warning.length")
+    options(warning.length = 7000L)
+    on.exit(options(warning.length = default_val))
+    stop("A Python environment for slendr has been created but the following",
+         "modules appear to be missing:", which_missing,
+         "\n\nPython environment summary:\n",
+         paste(capture.output(reticulate::py_config()), collapse = "\n"),
+         "\n\nInstalled Python modules:\n",
+         paste(utils::capture.output(print(packages)), collapse = "\n"),
+         call. = FALSE)
+  } else {
+    # pylib <<- reticulate::import_from_path(
+    #   "pylib",
+    #   path = system.file("python", package = "slendr"),
+    #   delay_load = TRUE
+    # )
+    if (!quiet)
+      message("Python virtual environment for slendr has been activated.")
   }
 }
 
@@ -1528,14 +1531,7 @@ setup_env <- function(quiet = FALSE, agree = FALSE, pip = FALSE) {
       if (!dir.exists(reticulate::miniconda_path()))
         reticulate::install_miniconda()
 
-      # parse the Python env name back to the list of dependencies
-      # (the environment is defined in .onAttach(), and this makes sure the
-      # dependencies are defined all in one place)
-      versions <- PYTHON_ENV %>% gsub("-", "==", .) %>% strsplit("_") %>% .[[1]]
-      python_version <- gsub("Python==", "", versions[1])
-      package_versions <- c(versions[-1], "pandas==2.3.3")
-
-      reticulate::conda_create(envname = PYTHON_ENV, python_version = python_version)
+      reticulate::conda_create(envname = PYTHON_ENV, python_version = PYTHON_VERSION)
       reticulate::use_condaenv(PYTHON_ENV, required = TRUE)
 
       # # some Python dependencies are  broken on M1 Mac architecture, so fallback
@@ -1548,9 +1544,9 @@ setup_env <- function(quiet = FALSE, agree = FALSE, pip = FALSE) {
       # on M-architecture Macs, so they will need to be installed by pip
       # no matter the user's preference (given by the pip function argument value)
       # TODO: check at some point later if tspop / pyslim are on conda for all systems
-      pip_only <- grepl("pandas|tspop|pyslim", package_versions)
-      reticulate::conda_install(envname = PYTHON_ENV, packages = package_versions[!pip_only], pip = pip)
-      reticulate::conda_install(envname = PYTHON_ENV, packages = package_versions[pip_only], pip = TRUE)
+      pip_only <- grepl("pandas|tspop|pyslim", PYTHON_DEPS)
+      reticulate::conda_install(envname = PYTHON_ENV, packages = PYTHON_DEPS[!pip_only], pip = pip)
+      reticulate::conda_install(envname = PYTHON_ENV, packages = PYTHON_DEPS[pip_only], pip = TRUE)
 
       if (!quiet) {
         message("======================================================================")

--- a/R/interface.R
+++ b/R/interface.R
@@ -1416,7 +1416,7 @@ schedule_sampling <- function(model, times, ..., locations = NULL, strict = FALS
 #'
 #' @export
 init_env <- function(uv = FALSE, quiet = FALSE) {
-  if (uv) {
+  if (uv || Sys.getenv("SLENDR_UV" == TRUE)) {
     reticulate::py_require(PYTHON_DEPS, PYTHON_VERSION)
   } else if (!check_dependencies(python = TRUE)) {
     stop("Could not activate slendr's Python environment because it is\n",

--- a/R/interface.R
+++ b/R/interface.R
@@ -1456,7 +1456,7 @@ init_env <- function(uv = FALSE, quiet = FALSE) {
     stop("A Python environment for slendr has been created but the following",
          " modules appear to be missing: ", which_missing,
          "\n\nPython environment summary:\n",
-         paste(capture.output(reticulate::py_config()), collapse = "\n"),
+         paste(utils::capture.output(reticulate::py_config()), collapse = "\n"),
          "\n\nInstalled Python modules:\n",
          paste(utils::capture.output(print(packages)), collapse = "\n"),
          call. = FALSE)

--- a/R/interface.R
+++ b/R/interface.R
@@ -1428,18 +1428,6 @@ init_env <- function(uv = FALSE, quiet = FALSE) {
     reticulate::use_condaenv(PYTHON_ENV, required = TRUE)
   }
 
-  # this is an awful workaround around the reticulate/Python bug which prevents
-  # import_from_path (see zzz.R) from working properly -- I'm getting nonsensical
-  #   Error in py_call_impl(callable, dots$args, dots$keywords) :
-  #     TypeError: integer argument expected, got float
-  # in places with no integer/float conversion in sight
-  #
-  # at least it prevents having to do things like:
-  # reticulate::py_run_string("def get_pedigree_ids(ts): return [ind.metadata['pedigree_id']
-  #                                                              for ind in ts.individuals()]")
-  # (moved from ts_read() here because this is a better place for loading our Python functions)
-  reticulate::source_python(file = system.file("pylib/pylib.py", package = "slendr"))
-
   missing <- c(
     "msprime" = !reticulate::py_module_available("msprime"),
     "tskit" = !reticulate::py_module_available("tskit"),
@@ -1461,11 +1449,24 @@ init_env <- function(uv = FALSE, quiet = FALSE) {
          paste(utils::capture.output(print(packages)), collapse = "\n"),
          call. = FALSE)
   } else {
+    # this is an awful workaround around the reticulate/Python bug which prevents
+    # import_from_path (see zzz.R) from working properly -- I'm getting nonsensical
+    #   Error in py_call_impl(callable, dots$args, dots$keywords) :
+    #     TypeError: integer argument expected, got float
+    # in places with no integer/float conversion in sight
+    #
+    # at least it prevents having to do things like:
+    # reticulate::py_run_string("def get_pedigree_ids(ts): return [ind.metadata['pedigree_id']
+    #                                                              for ind in ts.individuals()]")
+    # (moved from ts_read() here because this is a better place for loading our Python functions)
+    reticulate::source_python(file = system.file("pylib/pylib.py", package = "slendr"))
+
     # pylib <<- reticulate::import_from_path(
     #   "pylib",
     #   path = system.file("python", package = "slendr"),
     #   delay_load = TRUE
     # )
+
     if (!quiet)
       message("Python virtual environment for slendr has been activated.")
   }

--- a/R/interface.R
+++ b/R/interface.R
@@ -1437,7 +1437,13 @@ init_env <- function(uv = FALSE, quiet = FALSE) {
 
   if (any(missing)) {
     which_missing <- paste(names(missing)[missing], collapse = ", ")
+    tryCatch({
     packages <- reticulate::py_list_packages()[c("package", "version")]
+    }, error = function(msg) { 
+      stop("uv value:", uv, "\n", "env value:", Sys.getenv("SLENDR_UV"), "\n",
+       # cat(paste(capture.output(reticulate::py_config()), collapse = "\n")),
+        call. = FALSE)
+    })
     default_val <- getOption("warning.length")
     options(warning.length = 7000L)
     on.exit(options(warning.length = default_val))

--- a/R/interface.R
+++ b/R/interface.R
@@ -1417,7 +1417,7 @@ schedule_sampling <- function(model, times, ..., locations = NULL, strict = FALS
 #' @export
 init_env <- function(uv = FALSE, quiet = FALSE) {
   if (uv || Sys.getenv("SLENDR_UV") == "TRUE") {
-    reticulate::py_require(PYTHON_DEPS, PYTHON_VERSION)
+    reticulate::py_require(packages = PYTHON_DEPS, python_version = PYTHON_VERSION)
   } else if (!check_dependencies(python = TRUE)) {
     stop("Could not activate slendr's Python environment because it is\n",
          "not present on your system:\n\n", PYTHON_ENV, "\n\n",

--- a/R/utils.R
+++ b/R/utils.R
@@ -22,7 +22,7 @@ set_random_seed <- function(seed) {
 check_dependencies <- function(python = FALSE, slim = FALSE, quit = FALSE) {
   # check whether SLiM and Python are present (only if needed!)
   missing_slim <- if (slim) !is_slim_present() else FALSE
-  missing_python <- if (python) !is_slendr_env_present() else FALSE
+  missing_python <- if (python) (Sys.getenv("SLENDR_UV") == "TRUE" || !is_slendr_env_present()) else FALSE
 
   fail <- missing_slim || missing_python
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -22,7 +22,7 @@ set_random_seed <- function(seed) {
 check_dependencies <- function(python = FALSE, slim = FALSE, quit = FALSE) {
   # check whether SLiM and Python are present (only if needed!)
   missing_slim <- if (slim) !is_slim_present() else FALSE
-  missing_python <- if (python) (Sys.getenv("SLENDR_UV") == "TRUE" || !is_slendr_env_present()) else FALSE
+  missing_python <- if (python) (Sys.getenv("SLENDR_UV") != "TRUE" && !is_slendr_env_present()) else FALSE
 
   fail <- missing_slim || missing_python
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -27,17 +27,10 @@ check_dependencies <- function(python = FALSE, slim = FALSE, quit = FALSE) {
   fail <- missing_slim || missing_python
 
   if (fail) {
-    if (interactive()) {
-      error_slim <- if (missing_slim) "  - SLiM binary not found in the path" else ""
-      error_python <- if (missing_python) "  - Python environment (did you run setup_env()?)" else ""
-      stop(sprintf("Missing requirements of slendr:\n%s\n%s",
-                   error_slim, error_python), call. = FALSE)
-    } else {
-      if (quit)
-        q()
-      else
-        return(FALSE)
-    }
+    if (quit)
+      q()
+    else
+      return(FALSE)
   } else {
     return(invisible(TRUE))
   }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -9,11 +9,13 @@ tspop <- NULL
 
 # define slendr's required Python dependencies and compose an environment name
 # that will be used specifically for them
+PYTHON_VERSION <- "3.12"
+PYTHON_DEPS <- c("msprime==1.4.1", "tskit==1.0.2", "pyslim==1.1.1", "tspop==0.0.2")
 PYTHON_ENV <-
-  c("msprime==1.4.1", "tskit==1.0.2", "pyslim==1.1.1", "tspop==0.0.2") %>%
+  PYTHON_DEPS %>%
   gsub("==", "-", .) %>%
   paste(collapse = "_") %>%
-  paste0("Python-3.12_", .)
+  paste0("Python-", PYTHON_VERSION, "_", .)
 
 .onAttach <- function(libname, pkgname) {
   if (Sys.info()[["sysname"]] == "Windows") {
@@ -54,19 +56,6 @@ PYTHON_ENV <-
   }
 
   check_spatial_pkgs(error = FALSE)
-
-  if (!is_slendr_env_present()) {
-    if (!getOption("slendr.custom_env")) {
-      version <- strsplit(PYTHON_ENV, "_")[[1]] %>% gsub(".*-", "", .)
-      packageStartupMessage(
-        sprintf(paste0("A slendr Python (%s) environment with the necessary versions of\n",
-          "msprime (%s), tskit (%s), pyslim (%s), and tspop (%s)\nhas not been found.\n"),
-          version[1], version[2], version[3], version[4], version[5]),
-          "\nYou can setup a pre-configured environment with all of slendr's Python\n",
-          "dependencies automatically by running the function `setup_env()`."
-      )
-    }
-  }
 }
 
 .onLoad <- function(libname, pkgname) {
@@ -75,11 +64,4 @@ PYTHON_ENV <-
   pyslim <<- reticulate::import("pyslim", delay_load = TRUE)
   msp <<- reticulate::import("msprime", delay_load = TRUE)
   tspop <<- reticulate::import("tspop", delay_load = TRUE)
-
-  # setup slendr options (https://r-pkgs.org/r.html#when-you-do-need-side-effects)
-  op <- options()
-  op.slendr <- list(slendr.custom_env = FALSE)
-  toset <- !(names(op.slendr) %in% names(op))
-  if (any(toset)) options(op.slendr[toset])
-  invisible()
 }

--- a/generate_examples.R
+++ b/generate_examples.R
@@ -1,6 +1,4 @@
-path <- "~/Code/slendr"
-
-devtools::load_all(path)
+devtools::load_all()
 
 init_env()
 
@@ -25,7 +23,7 @@ model <- compile_model(
   populations = list(chimp, nea, afr, eur), gene_flow = gf,
   generation_time = 30,
   time_units = "years before present",
-  path = file.path(path, "inst/extdata/models/introgression"),
+  path = "inst/extdata/models/introgression",
   overwrite = TRUE, force = TRUE
 )
 

--- a/man/init_env.Rd
+++ b/man/init_env.Rd
@@ -4,9 +4,12 @@
 \alias{init_env}
 \title{Activate slendr's own dedicated Python environment}
 \usage{
-init_env(quiet = FALSE)
+init_env(uv = FALSE, quiet = FALSE)
 }
 \arguments{
+\item{uv}{Should an ephemeral Python environment be created via uv (instead
+of activating a permanent virtual environment created via \code{setup_env})?}
+
 \item{quiet}{Should informative messages be printed to the console? Default
 is \code{FALSE}.}
 }


### PR DESCRIPTION
_(Ignore the name of the git branch. GitHub doesn't allow changing branch names for opened PRs. We're not "switching" anything.)_

This is an attempt to provide a workaround for a broken interaction between the Python interpreters compiled by the conda project, the way its linked to system libraries (as described [here](https://discuss.python.org/t/moving-expat-version-or-symbol-checks-from-buildtime-to-runtime/105769) in detail) and the reticulate package which embeds a Python interpreter into an R session -- occasionally encountered on a subset of Linux systems.

The entire story so far is described [here](https://github.com/bodkan/slendr/issues/193), and is also related to an [earlier issue](https://github.com/bodkan/slendr/blob/289e2c6fb850c4b9f861e3d9d32c7c03a16978db/NEWS.md?plain=1#L28-L35) discovered in this context.

Because I don't see a way to solves this at the low-level where the problem actually happens (in fact, [the python.org bugtracker discussion](https://discuss.python.org/t/moving-expat-version-or-symbol-checks-from-buildtime-to-runtime/105769) makes it hard to even see how this could be fixed at the level of slendr), I decided to implement a (semi-)automatic fallback mechanism.

### Updated Python activation setup

1. For systems where no issue occurs (so far, all macOS tests, all Windows tests, most Linux tests), nothing changes. The following combo works just as before:

```
library(slendr)
setup_env()
init_env()
```

4. For systems where the reticulate-based embedding of the Python interpreter breaks (i.e., working `setup_env()` creation of a Python environment, broken embedding of Python into R in `init_env()`), users can continue using slendr's tskit/pyslim/msprime/tspop based features by doing the following:

```
library(slendr)
init_env(uv = TRUE)
```

Note that this skips the creation of a dedicated Python environment `setup_env()` entirely (because in situations where the embedding of Python into R breaks, creating the environment doesn't make sense). Instead, `init_env()` now contains a new argument `uv =` which, when set `TRUE`, uses the [relatively new functionality of the reticulate package to create ephemeral, throwaway Python environments](https://posit.co/blog/reticulate-1-41/). Because those environments do not utilize Python interpreter binary distributed by conda (what causes our issues right now), all scripts work without an issue.

Importantly, this change is completely backwards compatible, as calling `init_env()` (defaulting to `init_env(uv = FALSE)`) utilizes the reticulate-based Python machinery we've been using for years now.

Additionally, because I find the `init_env(uv = TRUE)` a bit annoying and easy to forget, there's also the possibility to set the environment variable `SLENDR_UV = TRUE` (for instance, in the standard `~/.Renviron` file), which makes `init_env()` (without arguments) behave in the exact same way as `init_env(uv = TRUE)`. This could be useful in containers, HPC settings which run into the same Python/conda/reticulate problems, etc.

### Further comments on uv, long-term perspective on integrating Python, etc.

The RStudio team behind reticulate has been pushing quite a bit for the adoption of uv as a new and popular tool to manage Python installations and environments. In fact, they seem to be promoting the usage of ephemeral throwaway Python environments for every individual script, utilizing the fact that uv is extremely fast and uses caching (so downloading and installing Python for every script run is quite fast). Relying on fixed, reused, more stable Python environments (which has been our strategy since the very beginning) seems to be a bit discouraged.

As a matter of fact, at first, I briefly considered porting the Python infrastructure of slendr to uv entirely. I decided not to do that for a number of reasons:

1. The primary case of using conda to fetch Python interpreter and install packages such as msprime or tskit is to allow slendr usage in challenging computational environments, namely HPC systems or Windows systems where users don't have to ability to install header libraries such as GSL, etc. This is the primary reason why conda was created in the first place, and uv doesn't help with that. uv is fast, but doesn't solve the distribution problem. (Side note: I'm a bit puzzled that this is never brought up in discussion about uv?) This alone was a reason why I originally disregarded uv for slendr completely -- its primary benefits are not that useful for us, the drawbacks potentially substantial.

2. Even though ephemeral uv-based Python environments can be downloaded and created very fast, an important application for slendr is simulation-based-inference. Although uv caching helps a lot with performance, sharing a single stable Python installation across thousands or even millions of simulation runs seems much more sense.

3. Although I used to use uv outside of R for a long time, I couldn't help to worry about the long-term stability of the tool given the VC backing of Astral (the developers of uv). Indeed, the recent [acquisition of Astral by ClosedAI](https://openai.com/index/openai-to-acquire-astral/) makes me even more skeptical about the long-term fate for uv.

In summary, uv provides a very useful emergency fallback for Linux (although still only for systems which do not suffer from issues related to installing libraries in HPC environments where users do not have root privileges), but it seems like a good idea not to switch to it completely.